### PR TITLE
Fallback to runner task container logs when Actions job logs endpoint returns 404

### DIFF
--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnostics.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnostics.java
@@ -16,6 +16,7 @@ import java.util.Map;
  * @param runs workflow runs returned by Gitea
  * @param jobsByRunId workflow jobs grouped by run id
  * @param jobLogsByJobId raw job logs grouped by job id
+ * @param taskContainerLogsByJobId fallback task container logs grouped by job id
  * @param runnerLogs runner container logs
  * @param giteaLogs Gitea container logs
  * @param warnings warnings emitted while collecting diagnostics
@@ -29,6 +30,7 @@ public record GiteaActionsDiagnostics(String traceId,
                                      List<GiteaActions.ActionRunSummary> runs,
                                      Map<Long, List<GiteaActions.ActionJobSummary>> jobsByRunId,
                                      Map<Long, byte[]> jobLogsByJobId,
+                                     Map<Long, List<GiteaActionsTaskContainerLog>> taskContainerLogsByJobId,
                                      String runnerLogs,
                                      String giteaLogs,
                                      List<String> warnings) {

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollector.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollector.java
@@ -19,17 +19,20 @@ final class GiteaActionsDiagnosticsCollector {
     private final Supplier<String> traceIdSupplier;
     private final Supplier<String> runnerLogsSupplier;
     private final Supplier<String> giteaLogsSupplier;
+    private final Supplier<List<GiteaActionsTaskContainerLog>> taskContainerLogsSupplier;
 
     GiteaActionsDiagnosticsCollector(GiteaApiClient apiClient,
                                      GiteaActions actions,
                                      Supplier<String> traceIdSupplier,
                                      Supplier<String> runnerLogsSupplier,
-                                     Supplier<String> giteaLogsSupplier) {
+                                     Supplier<String> giteaLogsSupplier,
+                                     Supplier<List<GiteaActionsTaskContainerLog>> taskContainerLogsSupplier) {
         this.apiClient = Objects.requireNonNull(apiClient, "apiClient");
         this.actions = Objects.requireNonNull(actions, "actions");
         this.traceIdSupplier = Objects.requireNonNull(traceIdSupplier, "traceIdSupplier");
         this.runnerLogsSupplier = Objects.requireNonNull(runnerLogsSupplier, "runnerLogsSupplier");
         this.giteaLogsSupplier = Objects.requireNonNull(giteaLogsSupplier, "giteaLogsSupplier");
+        this.taskContainerLogsSupplier = Objects.requireNonNull(taskContainerLogsSupplier, "taskContainerLogsSupplier");
     }
 
     GiteaActionsDiagnostics collect(String repoOwner, String repoName, Long runId) {
@@ -54,6 +57,7 @@ final class GiteaActionsDiagnosticsCollector {
 
         Map<Long, List<GiteaActions.ActionJobSummary>> jobsByRunId = new HashMap<>();
         Map<Long, byte[]> jobLogsByJobId = new HashMap<>();
+        Map<Long, List<GiteaActionsTaskContainerLog>> taskContainerLogsByJobId = new HashMap<>();
         if (selectedRunId != null) {
             try {
                 List<GiteaActions.ActionJobSummary> jobs = actions.listWorkflowJobs(repoOwner, repoName, selectedRunId);
@@ -64,7 +68,25 @@ final class GiteaActionsDiagnosticsCollector {
                             byte[] logs = actions.downloadWorkflowJobLogs(repoOwner, repoName, selectedRunId, job.id());
                             jobLogsByJobId.put(job.id(), logs);
                         } catch (RuntimeException e) {
-                            warnings.add("Failed to download logs for job " + job.id() + ": " + e.getMessage());
+                            if (isNotFound(e)) {
+                                warnings.add("Job log endpoint returned 404 for job " + job.id()
+                                        + "; falling back to runner task container logs");
+                                try {
+                                    List<GiteaActionsTaskContainerLog> taskLogs = taskContainerLogsSupplier.get();
+                                    if (taskLogs != null && !taskLogs.isEmpty()) {
+                                        taskContainerLogsByJobId.put(job.id(), taskLogs);
+                                        warnings.add("Captured " + taskLogs.size()
+                                                + " runner task container log(s) for job " + job.id());
+                                    } else {
+                                        warnings.add("No runner task container logs found for job " + job.id());
+                                    }
+                                } catch (RuntimeException fallbackError) {
+                                    warnings.add("Failed to capture runner task container logs for job " + job.id()
+                                            + ": " + fallbackError.getMessage());
+                                }
+                            } else {
+                                warnings.add("Failed to download logs for job " + job.id() + ": " + e.getMessage());
+                            }
                         }
                     }
                 }
@@ -88,9 +110,17 @@ final class GiteaActionsDiagnosticsCollector {
                 runs,
                 jobsByRunId,
                 jobLogsByJobId,
+                taskContainerLogsByJobId,
                 runnerLogs,
                 giteaLogs,
                 warnings);
+    }
+
+    private boolean isNotFound(RuntimeException e) {
+        if (e instanceof GiteaApiException apiException) {
+            return apiException.getStatusCode() == 404;
+        }
+        return false;
     }
 
     private boolean shouldCaptureJobLogs(GiteaActions.ActionJobSummary job) {

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsTaskContainerLog.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsTaskContainerLog.java
@@ -1,0 +1,10 @@
+package dev.promptlm.testutils.gitea;
+
+import java.time.Instant;
+import java.util.List;
+
+public record GiteaActionsTaskContainerLog(String containerId,
+                                          List<String> containerNames,
+                                          Instant createdAt,
+                                          String logs) {
+}

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
@@ -1,7 +1,9 @@
 package dev.promptlm.testutils.gitea;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.Frame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.awaitility.Awaitility;
@@ -20,12 +22,18 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Testcontainers wrapper for Gitea that provides easy setup and management for tests.
@@ -150,7 +158,8 @@ public class GiteaContainer {
                 actions,
                 () -> traceId,
                 () -> runner == null ? null : runner.getLogs(),
-                () -> container == null ? null : container.getLogs());
+                () -> container == null ? null : container.getLogs(),
+                this::collectRecentActionsTaskContainerLogs);
         this.actions.setDiagnosticsCollector(diagnosticsCollector);
         this.runnerRegistry = new GiteaRunnerRegistry(apiClient, logger);
         this.actionsSupport = new GiteaActionsSupport(httpClient, logger, this::getApiUrl, () -> adminToken);
@@ -668,6 +677,75 @@ public class GiteaContainer {
             logger.info("Removed {} stale Actions task container(s)", removed);
         }
         return removed;
+    }
+
+    List<GiteaActionsTaskContainerLog> collectRecentActionsTaskContainerLogs() {
+        int maxContainers = 5;
+        int tailLines = 2_000;
+        Duration maxWait = Duration.ofSeconds(10);
+
+        List<GiteaActionsTaskContainerLog> results = new java.util.ArrayList<>();
+        try {
+            var dockerClient = DockerClientFactory.instance().client();
+            List<Container> containers = dockerClient.listContainersCmd().withShowAll(true).exec();
+            containers.stream()
+                    .filter(container -> {
+                        String[] names = container.getNames();
+                        if (names == null || names.length == 0) {
+                            return false;
+                        }
+                        String joinedNames = String.join(",", names).toLowerCase(Locale.ROOT);
+                        return joinedNames.contains("gitea-actions-task-");
+                    })
+                    .sorted((a, b) -> Long.compare(b.getCreated() == null ? 0 : b.getCreated(),
+                            a.getCreated() == null ? 0 : a.getCreated()))
+                    .limit(maxContainers)
+                    .forEach(container -> {
+                        String logs = "";
+                        try {
+                            var callback = new ResultCallback.Adapter<Frame>() {
+                                private final java.io.ByteArrayOutputStream buffer = new java.io.ByteArrayOutputStream();
+
+                                @Override
+                                public void onNext(Frame frame) {
+                                    if (frame != null && frame.getPayload() != null) {
+                                        try {
+                                            buffer.write(frame.getPayload());
+                                        } catch (java.io.IOException ignored) {
+                                            // ignored
+                                        }
+                                    }
+                                }
+
+                                String content() {
+                                    return buffer.toString(java.nio.charset.StandardCharsets.UTF_8);
+                                }
+                            };
+
+                            dockerClient.logContainerCmd(container.getId())
+                                    .withStdOut(true)
+                                    .withStdErr(true)
+                                    .withTail(tailLines)
+                                    .exec(callback);
+
+                            callback.awaitCompletion(maxWait.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+                            logs = callback.content();
+                            callback.close();
+                        } catch (Exception e) {
+                            logs = "<failed to capture container logs: " + e.getMessage() + ">";
+                        }
+
+                        results.add(new GiteaActionsTaskContainerLog(
+                                container.getId(),
+                                container.getNames() == null ? List.of() : List.of(container.getNames()),
+                                container.getCreated() == null ? null : Instant.ofEpochSecond(container.getCreated()),
+                                logs));
+                    });
+        } catch (Exception e) {
+            logger.warn("Failed to collect Actions task container logs: {}", e.getMessage());
+        }
+
+        return results;
     }
 
     /**

--- a/src/test/java/dev/promptlm/testutils/CiWorkflowHarnessTest.java
+++ b/src/test/java/dev/promptlm/testutils/CiWorkflowHarnessTest.java
@@ -122,6 +122,13 @@ class CiWorkflowHarnessTest {
             System.err.println("--- job log " + jobId + " ---");
             System.err.println(new String(bytes, StandardCharsets.UTF_8));
         });
+        diagnostics.taskContainerLogsByJobId().forEach((jobId, logs) -> {
+            System.err.println("--- task container logs for job " + jobId + " ---");
+            logs.forEach(log -> {
+                System.err.println("--- task container " + log.containerId() + " " + log.containerNames() + " ---");
+                System.err.println(log.logs());
+            });
+        });
         if (diagnostics.runnerLogs() != null && !diagnostics.runnerLogs().isBlank()) {
             System.err.println("--- runner logs ---");
             System.err.println(diagnostics.runnerLogs());

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollectorTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollectorTest.java
@@ -9,6 +9,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -62,7 +63,8 @@ class GiteaActionsDiagnosticsCollectorTest {
                 actions,
                 () -> "trace-123",
                 () -> "runner-logs",
-                () -> "gitea-logs");
+                () -> "gitea-logs",
+                List::of);
 
         GiteaActionsDiagnostics diagnostics = collector.collect("owner", "repo", null);
 
@@ -73,9 +75,58 @@ class GiteaActionsDiagnosticsCollectorTest {
         assertThat(diagnostics.jobsByRunId()).containsKey(44L);
         assertThat(diagnostics.jobLogsByJobId()).containsKey(8L);
         assertThat(new String(diagnostics.jobLogsByJobId().get(8L))).contains("logs");
+        assertThat(diagnostics.taskContainerLogsByJobId()).isEmpty();
         assertThat(diagnostics.runnerLogs()).contains("runner-logs");
         assertThat(diagnostics.giteaLogs()).contains("gitea-logs");
         assertThat(logCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void fallsBackToTaskContainerLogsWhenJobLogEndpointReturns404() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        Logger logger = mock(Logger.class);
+
+        when(httpClient.send(argThat(request -> requestPath(request).contains("/jobs/8/logs")),
+                any(HttpResponse.BodyHandler.class)))
+                .thenAnswer(invocation -> {
+                    HttpRequest request = invocation.getArgument(0);
+                    URI uri = request.uri();
+                    return stubByteResponse(404, "missing".getBytes(), uri);
+                });
+
+        when(httpClient.send(argThat(request -> !requestPath(request).contains("/jobs/8/logs")),
+                any(HttpResponse.BodyHandler.class)))
+                .thenAnswer(invocation -> {
+                    HttpRequest request = invocation.getArgument(0);
+                    URI uri = request.uri();
+                    String path = requestPath(request);
+                    return stubStringResponse(200, responseBodyForPath(path), uri);
+                });
+
+        GiteaApiClient apiClient = new GiteaApiClient(
+                httpClient,
+                logger,
+                () -> "http://localhost:3000/api/v1",
+                () -> "token",
+                new ObjectMapper());
+
+        GiteaActions actions = new GiteaActions(apiClient, logger);
+        GiteaActionsDiagnosticsCollector collector = new GiteaActionsDiagnosticsCollector(
+                apiClient,
+                actions,
+                () -> "trace-123",
+                () -> "runner-logs",
+                () -> "gitea-logs",
+                () -> List.of(new GiteaActionsTaskContainerLog("cid", List.of("/gitea-actions-task-1"), null, "task-log")));
+
+        GiteaActionsDiagnostics diagnostics = collector.collect("owner", "repo", null);
+
+        assertThat(diagnostics.jobLogsByJobId()).doesNotContainKey(8L);
+        assertThat(diagnostics.taskContainerLogsByJobId()).containsKey(8L);
+        assertThat(diagnostics.taskContainerLogsByJobId().get(8L))
+                .extracting(GiteaActionsTaskContainerLog::logs)
+                .contains("task-log");
+        assertThat(diagnostics.warnings().stream().anyMatch(warning -> warning.contains("404"))).isTrue();
     }
 
     private static String requestPath(HttpRequest request) {


### PR DESCRIPTION
Implements issue #24.

## What changed
- Extends `GiteaActionsDiagnostics` with `taskContainerLogsByJobId` to carry fallback log data.
- When `GET /actions/runs/{runId}/jobs/{jobId}/logs` returns **404**, `collectActionsDiagnostics(...)` now captures recent `gitea-actions-task-*` container logs (tail) via Docker and attaches them under the failing `jobId`.
- Updates `CiWorkflowHarnessTest` diagnostics printing to include task container logs.
- Adds unit test coverage for the 404 fallback path.

## Notes
- Fallback is intentionally simple: it captures a bounded number of recent task containers and tails logs to keep output manageable.

Closes #24.