### PR TITLE
Improve Gitea Actions diagnostics for GitHub container jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <jackson.version>2.21.1</jackson.version>
         <mockito.version>5.23.0</mockito.version>
         <bytebuddy.version>1.18.7</bytebuddy.version>
+        <zstd.version>1.5.7-7</zstd.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
@@ -104,6 +105,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <version>${zstd.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnostics.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnostics.java
@@ -17,6 +17,7 @@ import java.util.Map;
  * @param jobsByRunId workflow jobs grouped by run id
  * @param jobLogsByJobId raw job logs grouped by job id
  * @param taskContainerLogsByJobId fallback task container logs grouped by job id
+ * @param giteaActionsLogFiles fallback Actions log files captured from inside the Gitea container
  * @param runnerLogs runner container logs
  * @param giteaLogs Gitea container logs
  * @param warnings warnings emitted while collecting diagnostics
@@ -31,6 +32,7 @@ public record GiteaActionsDiagnostics(String traceId,
                                      Map<Long, List<GiteaActions.ActionJobSummary>> jobsByRunId,
                                      Map<Long, byte[]> jobLogsByJobId,
                                      Map<Long, List<GiteaActionsTaskContainerLog>> taskContainerLogsByJobId,
+                                     List<GiteaActionsLogFile> giteaActionsLogFiles,
                                      String runnerLogs,
                                      String giteaLogs,
                                      List<String> warnings) {

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollector.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollector.java
@@ -20,19 +20,23 @@ final class GiteaActionsDiagnosticsCollector {
     private final Supplier<String> runnerLogsSupplier;
     private final Supplier<String> giteaLogsSupplier;
     private final Supplier<List<GiteaActionsTaskContainerLog>> taskContainerLogsSupplier;
+    private final Supplier<List<GiteaActionsLogFile>> giteaActionsLogFilesSupplier;
 
     GiteaActionsDiagnosticsCollector(GiteaApiClient apiClient,
                                      GiteaActions actions,
                                      Supplier<String> traceIdSupplier,
                                      Supplier<String> runnerLogsSupplier,
                                      Supplier<String> giteaLogsSupplier,
-                                     Supplier<List<GiteaActionsTaskContainerLog>> taskContainerLogsSupplier) {
+                                     Supplier<List<GiteaActionsTaskContainerLog>> taskContainerLogsSupplier,
+                                     Supplier<List<GiteaActionsLogFile>> giteaActionsLogFilesSupplier) {
         this.apiClient = Objects.requireNonNull(apiClient, "apiClient");
         this.actions = Objects.requireNonNull(actions, "actions");
         this.traceIdSupplier = Objects.requireNonNull(traceIdSupplier, "traceIdSupplier");
         this.runnerLogsSupplier = Objects.requireNonNull(runnerLogsSupplier, "runnerLogsSupplier");
         this.giteaLogsSupplier = Objects.requireNonNull(giteaLogsSupplier, "giteaLogsSupplier");
         this.taskContainerLogsSupplier = Objects.requireNonNull(taskContainerLogsSupplier, "taskContainerLogsSupplier");
+        this.giteaActionsLogFilesSupplier = Objects.requireNonNull(giteaActionsLogFilesSupplier,
+                "giteaActionsLogFilesSupplier");
     }
 
     GiteaActionsDiagnostics collect(String repoOwner, String repoName, Long runId) {
@@ -58,6 +62,8 @@ final class GiteaActionsDiagnosticsCollector {
         Map<Long, List<GiteaActions.ActionJobSummary>> jobsByRunId = new HashMap<>();
         Map<Long, byte[]> jobLogsByJobId = new HashMap<>();
         Map<Long, List<GiteaActionsTaskContainerLog>> taskContainerLogsByJobId = new HashMap<>();
+        List<GiteaActionsLogFile> giteaActionsLogFiles = List.of();
+        boolean giteaActionsLogsCaptured = false;
         if (selectedRunId != null) {
             try {
                 List<GiteaActions.ActionJobSummary> jobs = actions.listWorkflowJobs(repoOwner, repoName, selectedRunId);
@@ -70,7 +76,7 @@ final class GiteaActionsDiagnosticsCollector {
                         } catch (RuntimeException e) {
                             if (isNotFound(e)) {
                                 warnings.add("Job log endpoint returned 404 for job " + job.id()
-                                        + "; falling back to runner task container logs");
+                                        + "; falling back to runner task container logs and Gitea Actions log files");
                                 try {
                                     List<GiteaActionsTaskContainerLog> taskLogs = taskContainerLogsSupplier.get();
                                     if (taskLogs != null && !taskLogs.isEmpty()) {
@@ -83,6 +89,22 @@ final class GiteaActionsDiagnosticsCollector {
                                 } catch (RuntimeException fallbackError) {
                                     warnings.add("Failed to capture runner task container logs for job " + job.id()
                                             + ": " + fallbackError.getMessage());
+                                }
+                                if (!giteaActionsLogsCaptured) {
+                                    giteaActionsLogsCaptured = true;
+                                    try {
+                                        List<GiteaActionsLogFile> logFiles = giteaActionsLogFilesSupplier.get();
+                                        if (logFiles != null && !logFiles.isEmpty()) {
+                                            giteaActionsLogFiles = List.copyOf(logFiles);
+                                            warnings.add("Captured " + giteaActionsLogFiles.size()
+                                                    + " Gitea Actions log file(s) from the container filesystem");
+                                        } else {
+                                            warnings.add("No Gitea Actions log files found inside the Gitea container");
+                                        }
+                                    } catch (RuntimeException fallbackError) {
+                                        warnings.add("Failed to capture Gitea Actions log files: "
+                                                + fallbackError.getMessage());
+                                    }
                                 }
                             } else {
                                 warnings.add("Failed to download logs for job " + job.id() + ": " + e.getMessage());
@@ -111,6 +133,7 @@ final class GiteaActionsDiagnosticsCollector {
                 jobsByRunId,
                 jobLogsByJobId,
                 taskContainerLogsByJobId,
+                giteaActionsLogFiles,
                 runnerLogs,
                 giteaLogs,
                 warnings);

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsLogFile.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsLogFile.java
@@ -1,0 +1,6 @@
+package dev.promptlm.testutils.gitea;
+
+public record GiteaActionsLogFile(String path,
+                                  long sizeBytes,
+                                  String contents) {
+}

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
@@ -1,5 +1,6 @@
 package dev.promptlm.testutils.gitea;
 
+import com.github.luben.zstd.ZstdInputStream;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Container;
@@ -13,6 +14,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.ServerSocket;
@@ -56,6 +58,16 @@ public class GiteaContainer {
     private static final String DOCKER_IMAGE_LABEL = resolveImage("gitea.actions.job.image", "GITEA_ACTIONS_JOB_IMAGE",
             "docker://ghcr.io/catthehacker/ubuntu:act-22.04");
     private static final String NODE_INSTALL_SCRIPT_RESOURCE = "/dev/promptlm/testutils/gitea/node-install.sh";
+    private static final int ACTIONS_LOG_FILE_LIMIT = 8;
+    private static final long ACTIONS_LOG_MAX_FILE_SIZE_BYTES = 2L * 1024 * 1024;
+    private static final int ACTIONS_LOG_MAX_LINES = 400;
+    private static final List<String> ACTIONS_LOG_DIR_CANDIDATES = List.of(
+            "/var/lib/gitea/actions_log",
+            "/var/lib/gitea/data/actions_log",
+            "/var/lib/gitea/data/actions/log",
+            "/var/lib/gitea/log/actions",
+            "/data/gitea/actions_log",
+            "/data/gitea/log/actions");
 
     private static final class FixedPortGenericContainer<SELF extends FixedPortGenericContainer<SELF>> extends GenericContainer<SELF> {
 
@@ -159,7 +171,8 @@ public class GiteaContainer {
                 () -> traceId,
                 () -> runner == null ? null : runner.getLogs(),
                 () -> container == null ? null : container.getLogs(),
-                this::collectRecentActionsTaskContainerLogs);
+                this::collectRecentActionsTaskContainerLogs,
+                this::collectGiteaActionsLogFiles);
         this.actions.setDiagnosticsCollector(diagnosticsCollector);
         this.runnerRegistry = new GiteaRunnerRegistry(apiClient, logger);
         this.actionsSupport = new GiteaActionsSupport(httpClient, logger, this::getApiUrl, () -> adminToken);
@@ -746,6 +759,140 @@ public class GiteaContainer {
         }
 
         return results;
+    }
+
+    List<GiteaActionsLogFile> collectGiteaActionsLogFiles() {
+        if (container == null || !container.isRunning()) {
+            return List.of();
+        }
+
+        List<String> filePaths = listGiteaActionsLogFilePaths();
+        if (filePaths.isEmpty()) {
+            return List.of();
+        }
+
+        List<GiteaActionsLogFile> results = new java.util.ArrayList<>();
+        for (String filePath : filePaths) {
+            try {
+                long sizeBytes = readGiteaActionsLogFileSize(filePath);
+                String contents;
+                if (sizeBytes > ACTIONS_LOG_MAX_FILE_SIZE_BYTES) {
+                    contents = "<omitted: file size " + sizeBytes + " exceeds capture limit "
+                            + ACTIONS_LOG_MAX_FILE_SIZE_BYTES + " bytes>";
+                } else {
+                    byte[] rawContents = container.copyFileFromContainer(filePath, InputStream::readAllBytes);
+                    contents = decodeGiteaActionsLogFile(filePath, rawContents);
+                    contents = tailTextLines(contents, ACTIONS_LOG_MAX_LINES);
+                }
+                results.add(new GiteaActionsLogFile(filePath, sizeBytes, contents));
+            } catch (Exception e) {
+                logger.warn("Failed to capture Gitea Actions log file {}: {}", filePath, e.getMessage());
+            }
+        }
+        return results;
+    }
+
+    private List<String> listGiteaActionsLogFilePaths() {
+        String candidates = ACTIONS_LOG_DIR_CANDIDATES.stream()
+                .map(GiteaContainer::shellSingleQuote)
+                .collect(Collectors.joining(" "));
+        String fallbackRoots = List.of("/var/lib/gitea", "/data/gitea").stream()
+                .map(GiteaContainer::shellSingleQuote)
+                .collect(Collectors.joining(" "));
+        String command = "set -eu; found=''; " +
+                "for dir in " + candidates + "; do " +
+                "  if [ -d \"$dir\" ]; then " +
+                "    while IFS= read -r file; do found=\"$found$file\\n\"; done <<EOF\n" +
+                "$(find \"$dir\" -maxdepth 5 -type f 2>/dev/null | sort)\n" +
+                "EOF\n" +
+                "  fi; " +
+                "done; " +
+                "if [ -z \"$found\" ]; then " +
+                "  for root in " + fallbackRoots + "; do " +
+                "    if [ -d \"$root\" ]; then " +
+                "      find \"$root\" -maxdepth 5 -type f " +
+                "        \\( -path '*/actions*/*' -o -name '*actions*.log' -o -name 'actions*.log' \\) 2>/dev/null; " +
+                "    fi; " +
+                "  done | sort; " +
+                "else " +
+                "  printf '%b' \"$found\"; " +
+                "fi";
+        try {
+            var result = container.execInContainer("sh", "-lc", command);
+            return Arrays.stream(result.getStdout().split("\\R"))
+                    .map(String::trim)
+                    .filter(path -> !path.isEmpty())
+                    .distinct()
+                    .sorted()
+                    .limit(ACTIONS_LOG_FILE_LIMIT)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.warn("Failed to discover Gitea Actions log files: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private long readGiteaActionsLogFileSize(String filePath) {
+        try {
+            String escapedPath = shellSingleQuote(filePath);
+            var result = container.execInContainer(
+                    "sh",
+                    "-lc",
+                    "file=" + escapedPath + "; " +
+                            "if [ ! -f \"$file\" ]; then exit 0; fi; " +
+                            "wc -c < \"$file\" | tr -d '[:space:]'");
+            String stdout = result.getStdout();
+            if (stdout == null || stdout.isBlank()) {
+                return 0L;
+            }
+            return Long.parseLong(stdout.trim());
+        } catch (Exception e) {
+            logger.warn("Failed to read Gitea Actions log file size for {}: {}", filePath, e.getMessage());
+            return 0L;
+        }
+    }
+
+    private String decodeGiteaActionsLogFile(String filePath, byte[] rawContents) {
+        if (rawContents == null || rawContents.length == 0) {
+            return "";
+        }
+
+        byte[] decoded = rawContents;
+        if (filePath.endsWith(".zst")) {
+            try (var input = new ZstdInputStream(new java.io.ByteArrayInputStream(rawContents))) {
+                decoded = input.readAllBytes();
+            } catch (IOException e) {
+                logger.warn("Failed to decode Gitea Actions zstd log file {}: {}", filePath, e.getMessage());
+                return "<failed to decode zstd log file: " + e.getMessage() + ">";
+            }
+        }
+        return new String(decoded, StandardCharsets.UTF_8);
+    }
+
+    private String tailTextLines(String value, int maxLines) {
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+        if (maxLines <= 0) {
+            return "";
+        }
+        String[] lines = value.split("\\R");
+        if (lines.length <= maxLines) {
+            return value;
+        }
+        int start = Math.max(0, lines.length - maxLines);
+        StringBuilder builder = new StringBuilder();
+        for (int i = start; i < lines.length; i++) {
+            builder.append(lines[i]);
+            if (i < lines.length - 1) {
+                builder.append('\n');
+            }
+        }
+        return builder.toString();
+    }
+
+    private static String shellSingleQuote(String value) {
+        return "'" + value.replace("'", "'\"'\"'") + "'";
     }
 
     /**

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
@@ -58,16 +58,10 @@ public class GiteaContainer {
     private static final String DOCKER_IMAGE_LABEL = resolveImage("gitea.actions.job.image", "GITEA_ACTIONS_JOB_IMAGE",
             "docker://ghcr.io/catthehacker/ubuntu:act-22.04");
     private static final String NODE_INSTALL_SCRIPT_RESOURCE = "/dev/promptlm/testutils/gitea/node-install.sh";
+    private static final String ACTIONS_LOG_DIR = "/var/lib/gitea/actions_log";
     private static final int ACTIONS_LOG_FILE_LIMIT = 8;
     private static final long ACTIONS_LOG_MAX_FILE_SIZE_BYTES = 2L * 1024 * 1024;
     private static final int ACTIONS_LOG_MAX_LINES = 400;
-    private static final List<String> ACTIONS_LOG_DIR_CANDIDATES = List.of(
-            "/var/lib/gitea/actions_log",
-            "/var/lib/gitea/data/actions_log",
-            "/var/lib/gitea/data/actions/log",
-            "/var/lib/gitea/log/actions",
-            "/data/gitea/actions_log",
-            "/data/gitea/log/actions");
 
     private static final class FixedPortGenericContainer<SELF extends FixedPortGenericContainer<SELF>> extends GenericContainer<SELF> {
 
@@ -155,6 +149,8 @@ public class GiteaContainer {
                 .withEnv("GITEA__repository__ENABLE_PUSH_CREATE_USER", "true")
                 .withEnv("GITEA__repository__ENABLE_PUSH_CREATE_ORG", "true")
                 .withEnv("GITEA__queue__TYPE", "channel")
+                .withEnv("GITEA__actions__STORAGE_TYPE", "local")
+                .withEnv("GITEA__storage.actions_log__PATH", ACTIONS_LOG_DIR)
                 .withEnv("USER_UID", "1000")
                 .withEnv("USER_GID", "1000")
                 .waitingFor(Wait.forHttp("/").forPort(GITEA_PORT).forStatusCode(200))
@@ -793,30 +789,14 @@ public class GiteaContainer {
     }
 
     private List<String> listGiteaActionsLogFilePaths() {
-        String candidates = ACTIONS_LOG_DIR_CANDIDATES.stream()
-                .map(GiteaContainer::shellSingleQuote)
-                .collect(Collectors.joining(" "));
-        String fallbackRoots = List.of("/var/lib/gitea", "/data/gitea").stream()
-                .map(GiteaContainer::shellSingleQuote)
-                .collect(Collectors.joining(" "));
-        String command = "set -eu; found=''; " +
-                "for dir in " + candidates + "; do " +
-                "  if [ -d \"$dir\" ]; then " +
-                "    while IFS= read -r file; do found=\"$found$file\\n\"; done <<EOF\n" +
-                "$(find \"$dir\" -maxdepth 5 -type f 2>/dev/null | sort)\n" +
-                "EOF\n" +
-                "  fi; " +
-                "done; " +
-                "if [ -z \"$found\" ]; then " +
-                "  for root in " + fallbackRoots + "; do " +
-                "    if [ -d \"$root\" ]; then " +
-                "      find \"$root\" -maxdepth 5 -type f " +
-                "        \\( -path '*/actions*/*' -o -name '*actions*.log' -o -name 'actions*.log' \\) 2>/dev/null; " +
-                "    fi; " +
-                "  done | sort; " +
-                "else " +
-                "  printf '%b' \"$found\"; " +
-                "fi";
+        String command = """
+                set -eu
+                dir=%s
+                if [ ! -d "$dir" ]; then
+                  exit 0
+                fi
+                find "$dir" -maxdepth 5 -type f | sort
+                """.formatted(shellSingleQuote(ACTIONS_LOG_DIR));
         try {
             var result = container.execInContainer("sh", "-lc", command);
             return Arrays.stream(result.getStdout().split("\\R"))
@@ -834,13 +814,15 @@ public class GiteaContainer {
 
     private long readGiteaActionsLogFileSize(String filePath) {
         try {
-            String escapedPath = shellSingleQuote(filePath);
-            var result = container.execInContainer(
-                    "sh",
-                    "-lc",
-                    "file=" + escapedPath + "; " +
-                            "if [ ! -f \"$file\" ]; then exit 0; fi; " +
-                            "wc -c < \"$file\" | tr -d '[:space:]'");
+            String command = """
+                    set -eu
+                    file=%s
+                    if [ ! -f "$file" ]; then
+                      exit 0
+                    fi
+                    wc -c < "$file" | tr -d '[:space:]'
+                    """.formatted(shellSingleQuote(filePath));
+            var result = container.execInContainer("sh", "-lc", command);
             String stdout = result.getStdout();
             if (stdout == null || stdout.isBlank()) {
                 return 0L;

--- a/src/test/java/dev/promptlm/testutils/CiWorkflowHarnessTest.java
+++ b/src/test/java/dev/promptlm/testutils/CiWorkflowHarnessTest.java
@@ -129,6 +129,10 @@ class CiWorkflowHarnessTest {
                 System.err.println(log.logs());
             });
         });
+        diagnostics.giteaActionsLogFiles().forEach(logFile -> {
+            System.err.println("--- gitea actions log file " + logFile.path() + " (" + logFile.sizeBytes() + " bytes) ---");
+            System.err.println(logFile.contents());
+        });
         if (diagnostics.runnerLogs() != null && !diagnostics.runnerLogs().isBlank()) {
             System.err.println("--- runner logs ---");
             System.err.println(diagnostics.runnerLogs());

--- a/src/test/java/dev/promptlm/testutils/GithubWorkflowsContainerJobsIntegrationTest.java
+++ b/src/test/java/dev/promptlm/testutils/GithubWorkflowsContainerJobsIntegrationTest.java
@@ -1,0 +1,220 @@
+package dev.promptlm.testutils;
+
+import dev.promptlm.testutils.gitea.Gitea;
+import dev.promptlm.testutils.gitea.GiteaActions;
+import dev.promptlm.testutils.gitea.GiteaContainer;
+import dev.promptlm.testutils.gitea.WithGitea;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithGitea(actionsEnabled = true, createTestRepos = true, testRepoNames = {GithubWorkflowsContainerJobsIntegrationTest.REPO_NAME})
+class GithubWorkflowsContainerJobsIntegrationTest {
+
+    static final String REPO_NAME = "github-container-jobs-repo";
+    private static final String GROUP_ID = "dev.promptlm.workflow";
+    private static final String ARTIFACT_ID = "workflow-smoke";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("Runs a top-level .github/workflows workflow with job-level container jobs")
+    void shouldRunGithubWorkflowContainerJobs(@Gitea GiteaContainer gitea) throws Exception {
+        Assumptions.assumeTrue(isGitAvailable(), "git CLI is required for workflow integration test");
+
+        String version = "1.0.0-" + System.currentTimeMillis();
+        String owner = gitea.getAdminUsername();
+        String runnerCloneUrl = "http://localhost.localtest.me:%d/%s/%s.git".formatted(
+                URI.create(gitea.getWebUrl()).getPort(),
+                owner,
+                REPO_NAME);
+
+        gitea.waitForRepository(REPO_NAME);
+        gitea.enableRepositoryActions(owner, REPO_NAME);
+        gitea.resetRepositoryActionsState(owner, REPO_NAME);
+
+        Path repositoryDir = tempDir.resolve(REPO_NAME);
+        Files.createDirectories(repositoryDir);
+        writeWorkflowProject(repositoryDir, version, runnerCloneUrl, gitea);
+
+        String commitSha = seedRepository(repositoryDir, gitea, owner);
+
+        var report = waitForWorkflowReport(gitea, owner, commitSha);
+        if (report.run().conclusion() == null || !"success".equalsIgnoreCase(report.run().conclusion())) {
+            printDiagnostics(gitea.collectActionsDiagnostics(owner, REPO_NAME, report.run().id()));
+        }
+        assertThat(report.run().conclusion()).isEqualToIgnoringCase("success");
+        assertThat(report.allJobsTerminal()).isTrue();
+        assertThat(report.jobs())
+                .extracting(GiteaActions.ActionJobSummary::conclusion)
+                .contains("success");
+    }
+
+    private GiteaActions.ActionExecutionReport waitForWorkflowReport(GiteaContainer gitea,
+                                                                    String owner,
+                                                                    String commitSha) {
+        try {
+            return gitea.actions().waitForWorkflowRunBySha(
+                    owner,
+                    REPO_NAME,
+                    commitSha,
+                    Duration.ofMinutes(6),
+                    Duration.ofSeconds(2));
+        } catch (RuntimeException e) {
+            printDiagnostics(gitea.collectActionsDiagnostics(owner, REPO_NAME, null));
+            throw e;
+        }
+    }
+
+    private void writeWorkflowProject(Path repositoryDir,
+                                      String version,
+                                      String runnerCloneUrl,
+                                      GiteaContainer gitea) throws IOException {
+        Files.createDirectories(repositoryDir.resolve(".github/workflows"));
+        Files.createDirectories(repositoryDir.resolve("src/main/java/dev/promptlm/workflow"));
+
+        Map<String, String> placeholders = Map.of(
+                "GROUP_ID", GROUP_ID,
+                "ARTIFACT_ID", ARTIFACT_ID,
+                "VERSION", version,
+                "REPO_CLONE_URL", runnerCloneUrl,
+                "REPO_CLONE_USERNAME", gitea.getAdminUsername(),
+                "REPO_CLONE_TOKEN", gitea.getAdminToken());
+
+        writeTemplate("dev/promptlm/testutils/ciworkflow/pom.xml.template",
+                repositoryDir.resolve("pom.xml"),
+                placeholders);
+        writeTemplate("dev/promptlm/testutils/ciworkflow/WorkflowSmoke.java.template",
+                repositoryDir.resolve("src/main/java/dev/promptlm/workflow/WorkflowSmoke.java"),
+                placeholders);
+        writeTemplate("dev/promptlm/testutils/ciworkflow/github-container-jobs.yml.template",
+                repositoryDir.resolve(".github/workflows/github-container-jobs.yml"),
+                placeholders);
+    }
+
+    private void writeTemplate(String resourceName, Path target, Map<String, String> placeholders) throws IOException {
+        String template = loadResource(resourceName);
+        Files.createDirectories(target.getParent());
+        Files.writeString(target, applyPlaceholders(template, placeholders));
+    }
+
+    private String loadResource(String resourceName) throws IOException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        try (InputStream input = classLoader.getResourceAsStream(resourceName)) {
+            if (input == null) {
+                throw new IOException("Missing test resource template: " + resourceName);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private String applyPlaceholders(String template, Map<String, String> placeholders) {
+        String result = template;
+        for (var entry : placeholders.entrySet()) {
+            result = result.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        }
+        return result;
+    }
+
+    private String seedRepository(Path repositoryDir, GiteaContainer gitea, String owner) throws Exception {
+        String remoteUrl = "http://%s:%s@localhost:%d/%s/%s.git".formatted(
+                gitea.getAdminUsername(),
+                gitea.getAdminToken(),
+                URI.create(gitea.getWebUrl()).getPort(),
+                owner,
+                REPO_NAME);
+
+        runCommand(repositoryDir, "git", "init", "--initial-branch=main");
+        runCommand(repositoryDir, "git", "config", "user.name", gitea.getAdminUsername());
+        runCommand(repositoryDir, "git", "config", "user.email", gitea.getAdminUsername() + "@example.com");
+        runCommand(repositoryDir, "git", "remote", "add", "origin", remoteUrl);
+        runCommand(repositoryDir, "git", "add", ".");
+        runCommand(repositoryDir, "git", "commit", "-m", "Seed workflow project");
+        String commitSha = runCommand(repositoryDir, "git", "rev-parse", "HEAD").trim();
+        runCommand(repositoryDir, "git", "push", "--set-upstream", "origin", "main");
+        return commitSha;
+    }
+
+    private String runCommand(Path directory, String... command) throws Exception {
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.directory(directory.toFile());
+        builder.redirectErrorStream(true);
+        Process process = builder.start();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (InputStream input = process.getInputStream()) {
+            input.transferTo(output);
+        }
+        int exitCode = process.waitFor();
+        String result = output.toString(StandardCharsets.UTF_8);
+        if (exitCode != 0) {
+            throw new IllegalStateException("Command failed: " + String.join(" ", command) + "\n" + result);
+        }
+        return result;
+    }
+
+    private boolean isGitAvailable() {
+        try {
+            Process process = new ProcessBuilder("git", "--version").redirectErrorStream(true).start();
+            return process.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void printDiagnostics(dev.promptlm.testutils.gitea.GiteaActionsDiagnostics diagnostics) {
+        if (diagnostics == null) {
+            System.err.println("No Gitea Actions diagnostics available.");
+            return;
+        }
+
+        System.err.println("=== Gitea Actions Diagnostics ===");
+        System.err.println("traceId=" + diagnostics.traceId());
+        System.err.println("repo=" + diagnostics.repoOwner() + "/" + diagnostics.repoName());
+        System.err.println("capturedAt=" + diagnostics.capturedAt());
+        System.err.println("giteaWorkflowFiles=" + diagnostics.giteaWorkflowFiles());
+        System.err.println("githubWorkflowFiles=" + diagnostics.githubWorkflowFiles());
+        System.err.println("runs=" + diagnostics.runs());
+        System.err.println("jobsByRunId=" + diagnostics.jobsByRunId());
+        if (!diagnostics.warnings().isEmpty()) {
+            System.err.println("warnings=" + diagnostics.warnings());
+        }
+        diagnostics.jobLogsByJobId().forEach((jobId, bytes) -> {
+            System.err.println("--- job log " + jobId + " ---");
+            System.err.println(new String(bytes, StandardCharsets.UTF_8));
+        });
+        diagnostics.taskContainerLogsByJobId().forEach((jobId, logs) -> {
+            System.err.println("--- task container logs for job " + jobId + " ---");
+            logs.forEach(log -> {
+                System.err.println("--- task container " + log.containerId() + " " + log.containerNames() + " ---");
+                System.err.println(log.logs());
+            });
+        });
+        diagnostics.giteaActionsLogFiles().forEach(logFile -> {
+            System.err.println("--- gitea actions log file " + logFile.path() + " (" + logFile.sizeBytes() + " bytes) ---");
+            System.err.println(logFile.contents());
+        });
+        if (diagnostics.runnerLogs() != null && !diagnostics.runnerLogs().isBlank()) {
+            System.err.println("--- runner logs ---");
+            System.err.println(diagnostics.runnerLogs());
+        }
+        if (diagnostics.giteaLogs() != null && !diagnostics.giteaLogs().isBlank()) {
+            System.err.println("--- gitea logs ---");
+            System.err.println(diagnostics.giteaLogs());
+        }
+        System.err.println("=== End Gitea Actions Diagnostics ===");
+    }
+}

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollectorTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsCollectorTest.java
@@ -64,6 +64,7 @@ class GiteaActionsDiagnosticsCollectorTest {
                 () -> "trace-123",
                 () -> "runner-logs",
                 () -> "gitea-logs",
+                List::of,
                 List::of);
 
         GiteaActionsDiagnostics diagnostics = collector.collect("owner", "repo", null);
@@ -76,6 +77,7 @@ class GiteaActionsDiagnosticsCollectorTest {
         assertThat(diagnostics.jobLogsByJobId()).containsKey(8L);
         assertThat(new String(diagnostics.jobLogsByJobId().get(8L))).contains("logs");
         assertThat(diagnostics.taskContainerLogsByJobId()).isEmpty();
+        assertThat(diagnostics.giteaActionsLogFiles()).isEmpty();
         assertThat(diagnostics.runnerLogs()).contains("runner-logs");
         assertThat(diagnostics.giteaLogs()).contains("gitea-logs");
         assertThat(logCalls.get()).isEqualTo(1);
@@ -117,7 +119,8 @@ class GiteaActionsDiagnosticsCollectorTest {
                 () -> "trace-123",
                 () -> "runner-logs",
                 () -> "gitea-logs",
-                () -> List.of(new GiteaActionsTaskContainerLog("cid", List.of("/gitea-actions-task-1"), null, "task-log")));
+                () -> List.of(new GiteaActionsTaskContainerLog("cid", List.of("/gitea-actions-task-1"), null, "task-log")),
+                () -> List.of(new GiteaActionsLogFile("/var/lib/gitea/actions_log/build.log", 42L, "gitea-actions-log")));
 
         GiteaActionsDiagnostics diagnostics = collector.collect("owner", "repo", null);
 
@@ -126,6 +129,9 @@ class GiteaActionsDiagnosticsCollectorTest {
         assertThat(diagnostics.taskContainerLogsByJobId().get(8L))
                 .extracting(GiteaActionsTaskContainerLog::logs)
                 .contains("task-log");
+        assertThat(diagnostics.giteaActionsLogFiles())
+                .extracting(GiteaActionsLogFile::contents)
+                .contains("gitea-actions-log");
         assertThat(diagnostics.warnings().stream().anyMatch(warning -> warning.contains("404"))).isTrue();
     }
 

--- a/src/test/resources/dev/promptlm/testutils/ciworkflow/github-container-jobs.yml.template
+++ b/src/test/resources/dev/promptlm/testutils/ciworkflow/github-container-jobs.yml.template
@@ -1,0 +1,43 @@
+name: github-container-jobs
+on:
+  push:
+    branches:
+      - main
+
+env:
+  VERSION: "{{VERSION}}"
+  REPO_CLONE_URL: "{{REPO_CLONE_URL}}"
+  REPO_CLONE_USERNAME: "{{REPO_CLONE_USERNAME}}"
+  REPO_CLONE_TOKEN: "{{REPO_CLONE_TOKEN}}"
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        run: |
+          echo "version=${VERSION}"
+
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    container: maven:3.9.9-eclipse-temurin-21
+    steps:
+      - name: Shell checkout
+        run: |
+          rm -rf repo
+          git clone "http://${REPO_CLONE_USERNAME}:${REPO_CLONE_TOKEN}@${REPO_CLONE_URL#http://}" repo
+      - name: Build
+        run: |
+          cd repo
+          mvn -B -ntp versions:set -DnewVersion=${VERSION}
+          mvn -B -ntp clean verify
+
+  deploy:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    container: maven:3.9.9-eclipse-temurin-21
+    steps:
+      - name: Deploy placeholder
+        run: |
+          echo "deploy ok"


### PR DESCRIPTION
## Summary
- capture internal Gitea Actions log files when the job logs API returns 404
- decode compressed Gitea actions logs so failing job output is readable in test diagnostics
- fix the GitHub workflow container-job regression fixture by filling the Maven template placeholders

## Testing
- ./mvnw -Dtest=dev.promptlm.testutils.gitea.GiteaActionsDiagnosticsCollectorTest test
- ./mvnw -Dtest=dev.promptlm.testutils.GithubWorkflowsContainerJobsIntegrationTest test
- ./mvnw test

Closes #27