### PR TITLE
Provide standard Artifactory Actions workflow contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ class IntegrationTest {
 }
 ```
 
+## Artifactory workflow contract
+
+When `@WithArtifactory` starts the harness, it publishes a default workflow-facing
+contract for downstream Actions-based tests:
+
+- `ARTIFACTORY_URL`
+- `ARTIFACTORY_REPOSITORY`
+- `ARTIFACTORY_USERNAME`
+- `ARTIFACTORY_PASSWORD`
+
+These values are available as system properties under the same names, and
+`ArtifactoryContainer` exposes helpers to use them directly:
+
+```java
+Map<String, String> variables = artifactory.standardActionsVariables();
+artifactory.configureRepositoryActionsVariables(gitea, gitea.getAdminUsername(), "demo");
+```
+
+`ARTIFACTORY_URL` defaults to the runner-accessible API URL so Gitea Actions job
+containers can reach the harness. If you need custom values, start from the
+default map, override the keys you want, and apply that map explicitly:
+
+```java
+Map<String, String> variables = artifactory.standardActionsVariables();
+variables.put(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL, artifactory.getApiUrl());
+artifactory.configureRepositoryActionsVariables(gitea, gitea.getAdminUsername(), "demo", variables);
+```
+
+The existing `artifactory.*` system properties remain available for host-side
+test code that talks to Artifactory directly.
+
 ## Gitea Actions support
 
 `GiteaContainer` exposes a lightweight Actions facade for inspecting workflow runs and logs:

--- a/src/main/java/dev/promptlm/testutils/artifactory/ArtifactoryContainer.java
+++ b/src/main/java/dev/promptlm/testutils/artifactory/ArtifactoryContainer.java
@@ -2,6 +2,7 @@ package dev.promptlm.testutils.artifactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.promptlm.testutils.gitea.GiteaContainer;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
@@ -20,6 +21,9 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Testcontainers wrapper for JFrog Artifactory OSS that provides easy setup and management for tests.
@@ -32,17 +36,33 @@ import java.util.Base64;
  * - Spring Boot integration via system properties
  */
 public class ArtifactoryContainer {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(ArtifactoryContainer.class);
     private static final String ARTIFACTORY_IMAGE = "releases-docker.jfrog.io/jfrog/artifactory-oss:7.77.5";
     private static final int ARTIFACTORY_PORT = 8081;
     private static final int ARTIFACTORY_ACCESS_PORT = 8082;
-    
+    /**
+     * Standard Gitea Actions variable name for the runner-accessible Artifactory API base URL.
+     */
+    public static final String ACTIONS_VARIABLE_ARTIFACTORY_URL = "ARTIFACTORY_URL";
+    /**
+     * Standard Gitea Actions variable name for the Maven repository key.
+     */
+    public static final String ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY = "ARTIFACTORY_REPOSITORY";
+    /**
+     * Standard Gitea Actions variable name for the deployer username.
+     */
+    public static final String ACTIONS_VARIABLE_ARTIFACTORY_USERNAME = "ARTIFACTORY_USERNAME";
+    /**
+     * Standard Gitea Actions variable name for the deployer password.
+     */
+    public static final String ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD = "ARTIFACTORY_PASSWORD";
+
     private final GenericContainer<?> container;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
     private boolean loggingEnabled = false;
-    
+
     private String adminUsername = "admin";
     private String adminPassword = "password"; // Default Artifactory OSS password
     private String deployerUsername = "ci-deployer";
@@ -50,7 +70,7 @@ public class ArtifactoryContainer {
     private String deployerEmail = "ci-deployer@example.com";
     private String mavenRepoName = "libs-release-local";
     private String networkAlias = "artifactory";
-    
+
     /**
      * Create a new Artifactory test harness with default users and repository names.
      */
@@ -89,7 +109,7 @@ public class ArtifactoryContainer {
         this.loggingEnabled = true;
         return this;
     }
-    
+
     /**
      * Configure the admin user credentials
      *
@@ -102,7 +122,7 @@ public class ArtifactoryContainer {
         this.adminPassword = password;
         return this;
     }
-    
+
     /**
      * Configure the CI deployer user
      *
@@ -117,7 +137,7 @@ public class ArtifactoryContainer {
         this.deployerEmail = email;
         return this;
     }
-    
+
     /**
      * Configure the Maven repository name
      *
@@ -167,12 +187,12 @@ public class ArtifactoryContainer {
 
         // Detect correct admin password
         detectAdminPassword();
-        
+
         // Initialize repositories and users
         createMavenRepository();
         createDeployerUser();
         createDeployerPermissions();
-        
+
         logger.info("Artifactory container started successfully at: {}", getWebUrl());
         logger.info("Admin user: {} / {}", adminUsername, maskSecret(adminPassword));
         logger.info("Deployer user: {} / {}", deployerUsername, maskSecret(deployerPassword));
@@ -200,7 +220,7 @@ public class ArtifactoryContainer {
             container.stop();
         }
     }
-    
+
     /**
      * Get the web URL for accessing Artifactory UI
      *
@@ -209,7 +229,7 @@ public class ArtifactoryContainer {
     public String getWebUrl() {
         return "http://" + resolveHost() + ":" + container.getMappedPort(ARTIFACTORY_PORT);
     }
-    
+
     /**
      * Get the API URL for Artifactory API calls
      *
@@ -236,7 +256,7 @@ public class ArtifactoryContainer {
     public String getRunnerAccessibleApiUrl() {
         return "http://host.testcontainers.internal:" + container.getMappedPort(ARTIFACTORY_PORT) + "/artifactory";
     }
-    
+
     /**
      * Get the Maven repository URL for deployment
      *
@@ -245,7 +265,7 @@ public class ArtifactoryContainer {
     public String getMavenRepositoryUrl() {
         return getApiUrl() + "/" + mavenRepoName;
     }
-    
+
     /**
      * Get the admin username
      *
@@ -254,7 +274,7 @@ public class ArtifactoryContainer {
     public String getAdminUsername() {
         return adminUsername;
     }
-    
+
     /**
      * Get the admin password
      *
@@ -263,7 +283,7 @@ public class ArtifactoryContainer {
     public String getAdminPassword() {
         return adminPassword;
     }
-    
+
     /**
      * Get the deployer username
      *
@@ -272,7 +292,7 @@ public class ArtifactoryContainer {
     public String getDeployerUsername() {
         return deployerUsername;
     }
-    
+
     /**
      * Get the deployer password
      *
@@ -297,7 +317,7 @@ public class ArtifactoryContainer {
     public String getMavenRepositoryName() {
         return mavenRepoName;
     }
-    
+
     /**
      * Get Basic Auth header for deployer user
      *
@@ -307,7 +327,52 @@ public class ArtifactoryContainer {
         String credentials = deployerUsername + ":" + deployerPassword;
         return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
     }
-    
+
+    /**
+     * Return the standard workflow-facing Artifactory contract for Actions-based builds.
+     * <p>
+     * The returned map is a fresh mutable copy so callers can override any default before
+     * applying it to a repository.
+     *
+     * @return default Actions variable map
+     */
+    public Map<String, String> standardActionsVariables() {
+        Map<String, String> variables = new LinkedHashMap<>();
+        variables.put(ACTIONS_VARIABLE_ARTIFACTORY_URL, getRunnerAccessibleApiUrl());
+        variables.put(ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY, getMavenRepositoryName());
+        variables.put(ACTIONS_VARIABLE_ARTIFACTORY_USERNAME, getDeployerUsername());
+        variables.put(ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD, getDeployerPassword());
+        return variables;
+    }
+
+    /**
+     * Apply the default Artifactory Actions variable contract to a Gitea repository.
+     *
+     * @param gitea configured Gitea harness
+     * @param repoOwner repository owner
+     * @param repoName repository name
+     */
+    public void configureRepositoryActionsVariables(GiteaContainer gitea, String repoOwner, String repoName) {
+        configureRepositoryActionsVariables(gitea, repoOwner, repoName, standardActionsVariables());
+    }
+
+    /**
+     * Apply the provided Artifactory Actions variable map to a Gitea repository.
+     *
+     * @param gitea configured Gitea harness
+     * @param repoOwner repository owner
+     * @param repoName repository name
+     * @param variables variable map to create or update
+     */
+    public void configureRepositoryActionsVariables(GiteaContainer gitea,
+                                                    String repoOwner,
+                                                    String repoName,
+                                                    Map<String, String> variables) {
+        Objects.requireNonNull(gitea, "gitea must not be null");
+        Objects.requireNonNull(variables, "variables must not be null");
+        variables.forEach((key, value) -> gitea.ensureRepositoryActionsVariable(repoOwner, repoName, key, value));
+    }
+
     /**
      * Check if a repository exists
      *

--- a/src/main/java/dev/promptlm/testutils/artifactory/ArtifactoryTestExtension.java
+++ b/src/main/java/dev/promptlm/testutils/artifactory/ArtifactoryTestExtension.java
@@ -19,31 +19,29 @@ class ArtifactoryTestExtension implements BeforeAllCallback, AfterAllCallback, P
     private static final Logger logger = LoggerFactory.getLogger(ArtifactoryTestExtension.class);
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create("promptlm", "artifactory");
     private static final String STORE_KEY = "container";
-    private static final String REPO_REMOTE_URL = "REPO_REMOTE_URL";
-    private static final String REPO_REMOTE_USERNAME = "REPO_REMOTE_USERNAME";
-    private static final String REPO_REMOTE_TOKEN = "REPO_REMOTE_TOKEN";
-    private static final String ARTIFACTORY_URL = "artifactory.url";
-    private static final String ARTIFACTORY_MAVEN_REPO_URL = "artifactory.maven.repository.url";
-    private static final String ARTIFACTORY_ADMIN_USERNAME = "artifactory.admin.username";
-    private static final String ARTIFACTORY_ADMIN_PASSWORD = "artifactory.admin.password";
-    private static final String ARTIFACTORY_DEPLOYER_USERNAME = "artifactory.deployer.username";
-    private static final String ARTIFACTORY_DEPLOYER_PASSWORD = "artifactory.deployer.password";
-    private static final String ARTIFACTORY_MAVEN_REPO_NAME = "artifactory.maven.repository.name";
-    private static final String ARTIFACTORY_INTERNAL_API_URL = "artifactory.internal.api.url";
-    private static final String ARTIFACTORY_RUNNER_API_URL = "artifactory.runner.api.url";
+    private static final String ARTIFACTORY_PROPERTY_URL = "artifactory.url";
+    private static final String ARTIFACTORY_PROPERTY_MAVEN_REPO_URL = "artifactory.maven.repository.url";
+    private static final String ARTIFACTORY_PROPERTY_ADMIN_USERNAME = "artifactory.admin.username";
+    private static final String ARTIFACTORY_PROPERTY_ADMIN_PASSWORD = "artifactory.admin.password";
+    private static final String ARTIFACTORY_PROPERTY_DEPLOYER_USERNAME = "artifactory.deployer.username";
+    private static final String ARTIFACTORY_PROPERTY_DEPLOYER_PASSWORD = "artifactory.deployer.password";
+    private static final String ARTIFACTORY_PROPERTY_MAVEN_REPO_NAME = "artifactory.maven.repository.name";
+    private static final String ARTIFACTORY_PROPERTY_INTERNAL_API_URL = "artifactory.internal.api.url";
+    private static final String ARTIFACTORY_PROPERTY_RUNNER_API_URL = "artifactory.runner.api.url";
     private static final String[] PROPERTY_KEYS = {
-            REPO_REMOTE_URL,
-            REPO_REMOTE_USERNAME,
-            REPO_REMOTE_TOKEN,
-            ARTIFACTORY_URL,
-            ARTIFACTORY_MAVEN_REPO_URL,
-            ARTIFACTORY_ADMIN_USERNAME,
-            ARTIFACTORY_ADMIN_PASSWORD,
-            ARTIFACTORY_DEPLOYER_USERNAME,
-            ARTIFACTORY_DEPLOYER_PASSWORD,
-            ARTIFACTORY_MAVEN_REPO_NAME,
-            ARTIFACTORY_INTERNAL_API_URL,
-            ARTIFACTORY_RUNNER_API_URL
+            ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL,
+            ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY,
+            ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME,
+            ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD,
+            ARTIFACTORY_PROPERTY_URL,
+            ARTIFACTORY_PROPERTY_MAVEN_REPO_URL,
+            ARTIFACTORY_PROPERTY_ADMIN_USERNAME,
+            ARTIFACTORY_PROPERTY_ADMIN_PASSWORD,
+            ARTIFACTORY_PROPERTY_DEPLOYER_USERNAME,
+            ARTIFACTORY_PROPERTY_DEPLOYER_PASSWORD,
+            ARTIFACTORY_PROPERTY_MAVEN_REPO_NAME,
+            ARTIFACTORY_PROPERTY_INTERNAL_API_URL,
+            ARTIFACTORY_PROPERTY_RUNNER_API_URL
     };
 
     @Override
@@ -154,19 +152,17 @@ class ArtifactoryTestExtension implements BeforeAllCallback, AfterAllCallback, P
     }
 
     private void configureSystemProperties(ArtifactoryContainer container) {
-        setProperty(REPO_REMOTE_URL, container.getMavenRepositoryUrl());
-        setProperty(REPO_REMOTE_USERNAME, container.getDeployerUsername());
-        setProperty(REPO_REMOTE_TOKEN, container.getDeployerPassword());
+        container.standardActionsVariables().forEach(this::setProperty);
 
-        setProperty(ARTIFACTORY_URL, container.getApiUrl());
-        setProperty(ARTIFACTORY_MAVEN_REPO_URL, container.getMavenRepositoryUrl());
-        setProperty(ARTIFACTORY_ADMIN_USERNAME, container.getAdminUsername());
-        setProperty(ARTIFACTORY_ADMIN_PASSWORD, container.getAdminPassword());
-        setProperty(ARTIFACTORY_DEPLOYER_USERNAME, container.getDeployerUsername());
-        setProperty(ARTIFACTORY_DEPLOYER_PASSWORD, container.getDeployerPassword());
-        setProperty(ARTIFACTORY_MAVEN_REPO_NAME, container.getMavenRepositoryName());
-        setProperty(ARTIFACTORY_INTERNAL_API_URL, container.getInternalApiUrl());
-        setProperty(ARTIFACTORY_RUNNER_API_URL, container.getRunnerAccessibleApiUrl());
+        setProperty(ARTIFACTORY_PROPERTY_URL, container.getApiUrl());
+        setProperty(ARTIFACTORY_PROPERTY_MAVEN_REPO_URL, container.getMavenRepositoryUrl());
+        setProperty(ARTIFACTORY_PROPERTY_ADMIN_USERNAME, container.getAdminUsername());
+        setProperty(ARTIFACTORY_PROPERTY_ADMIN_PASSWORD, container.getAdminPassword());
+        setProperty(ARTIFACTORY_PROPERTY_DEPLOYER_USERNAME, container.getDeployerUsername());
+        setProperty(ARTIFACTORY_PROPERTY_DEPLOYER_PASSWORD, container.getDeployerPassword());
+        setProperty(ARTIFACTORY_PROPERTY_MAVEN_REPO_NAME, container.getMavenRepositoryName());
+        setProperty(ARTIFACTORY_PROPERTY_INTERNAL_API_URL, container.getInternalApiUrl());
+        setProperty(ARTIFACTORY_PROPERTY_RUNNER_API_URL, container.getRunnerAccessibleApiUrl());
     }
 
     private void clearSystemProperties() {

--- a/src/test/java/dev/promptlm/testutils/artifactory/ArtifactoryAnnotationIntegrationTest.java
+++ b/src/test/java/dev/promptlm/testutils/artifactory/ArtifactoryAnnotationIntegrationTest.java
@@ -10,6 +10,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,10 +40,24 @@ class ArtifactoryAnnotationIntegrationTest {
         String repositoryUrl = System.getProperty("artifactory.maven.repository.url");
         String deployerUser = System.getProperty("artifactory.deployer.username");
         String deployerPassword = System.getProperty("artifactory.deployer.password");
+        Map<String, String> actionsVariables = artifactory.standardActionsVariables();
 
         assertThat(repositoryUrl).isNotBlank();
         assertThat(deployerUser).isNotBlank();
         assertThat(deployerPassword).isNotBlank();
+        assertThat(actionsVariables)
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL, artifactory.getRunnerAccessibleApiUrl())
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY, artifactory.getMavenRepositoryName())
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME, deployerUser)
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD, deployerPassword);
+        assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL))
+                .isEqualTo(artifactory.getRunnerAccessibleApiUrl());
+        assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY))
+                .isEqualTo(artifactory.getMavenRepositoryName());
+        assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME))
+                .isEqualTo(deployerUser);
+        assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD))
+                .isEqualTo(deployerPassword);
 
         // Artifactory should report healthy via REST API when using admin credentials
         HttpResponse<String> pingResponse = httpClient.send(
@@ -98,10 +113,10 @@ class ArtifactoryAnnotationIntegrationTest {
         assertThat(getResponse.statusCode()).isEqualTo(200);
         assertThat(getResponse.body()).contains(dummyJarContent);
 
-        // Ensure legacy properties are also populated for backward compatibility
-        assertThat(System.getProperty("REPO_REMOTE_URL")).isEqualTo(repositoryUrl);
-        assertThat(System.getProperty("REPO_REMOTE_USERNAME")).isEqualTo(deployerUser);
-        assertThat(System.getProperty("REPO_REMOTE_TOKEN")).isEqualTo(deployerPassword);
+        // Artifactory should no longer publish unrelated repo-remote properties
+        assertThat(System.getProperty("REPO_REMOTE_URL")).isNull();
+        assertThat(System.getProperty("REPO_REMOTE_USERNAME")).isNull();
+        assertThat(System.getProperty("REPO_REMOTE_TOKEN")).isNull();
 
         // Deployer credentials must authenticate against REST API as well
         HttpResponse<String> deployerPing = httpClient.send(

--- a/src/test/java/dev/promptlm/testutils/artifactory/ArtifactoryContainerContractTest.java
+++ b/src/test/java/dev/promptlm/testutils/artifactory/ArtifactoryContainerContractTest.java
@@ -1,0 +1,64 @@
+package dev.promptlm.testutils.artifactory;
+
+import dev.promptlm.testutils.gitea.GiteaContainer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ArtifactoryContainerContractTest {
+
+    @Test
+    void standardActionsVariablesExposeDocumentedWorkflowContract() {
+        ArtifactoryContainer artifactory = contractContainer();
+
+        Map<String, String> variables = artifactory.standardActionsVariables();
+
+        assertThat(variables)
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL,
+                        "http://host.testcontainers.internal:8081/artifactory")
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY, "ci-maven-local")
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME, "ci-deployer")
+                .containsEntry(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD, "ci-deployer-password");
+
+        variables.put(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL, "http://override.test/artifactory");
+        assertThat(variables.get(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL))
+                .isEqualTo("http://override.test/artifactory");
+    }
+
+    @Test
+    void configureRepositoryActionsVariablesAppliesStandardContractToGitea() {
+        ArtifactoryContainer artifactory = contractContainer();
+        GiteaContainer gitea = mock(GiteaContainer.class);
+
+        artifactory.configureRepositoryActionsVariables(gitea, "owner", "repo");
+
+        verify(gitea).ensureRepositoryActionsVariable("owner", "repo",
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL,
+                "http://host.testcontainers.internal:8081/artifactory");
+        verify(gitea).ensureRepositoryActionsVariable("owner", "repo",
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY,
+                "ci-maven-local");
+        verify(gitea).ensureRepositoryActionsVariable("owner", "repo",
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME,
+                "ci-deployer");
+        verify(gitea).ensureRepositoryActionsVariable("owner", "repo",
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD,
+                "ci-deployer-password");
+    }
+
+    private ArtifactoryContainer contractContainer() {
+        ArtifactoryContainer artifactory = mock(ArtifactoryContainer.class, CALLS_REAL_METHODS);
+        doReturn("http://host.testcontainers.internal:8081/artifactory")
+                .when(artifactory).getRunnerAccessibleApiUrl();
+        doReturn("ci-maven-local").when(artifactory).getMavenRepositoryName();
+        doReturn("ci-deployer").when(artifactory).getDeployerUsername();
+        doReturn("ci-deployer-password").when(artifactory).getDeployerPassword();
+        return artifactory;
+    }
+}

--- a/src/test/java/dev/promptlm/testutils/artifactory/ArtifactoryTestExtensionUnitTest.java
+++ b/src/test/java/dev/promptlm/testutils/artifactory/ArtifactoryTestExtensionUnitTest.java
@@ -23,9 +23,10 @@ class ArtifactoryTestExtensionUnitTest {
 
     @AfterEach
     void clearProperties() {
-        System.clearProperty("REPO_REMOTE_URL");
-        System.clearProperty("REPO_REMOTE_USERNAME");
-        System.clearProperty("REPO_REMOTE_TOKEN");
+        System.clearProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL);
+        System.clearProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY);
+        System.clearProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME);
+        System.clearProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD);
         System.clearProperty("artifactory.url");
         System.clearProperty("artifactory.maven.repository.url");
         System.clearProperty("artifactory.admin.username");
@@ -48,6 +49,7 @@ class ArtifactoryTestExtensionUnitTest {
             when(mock.withDeployerUser(any(), any(), any())).thenReturn(mock);
             when(mock.withMavenRepository(any())).thenReturn(mock);
             when(mock.withNetworkAlias(any())).thenReturn(mock);
+            when(mock.standardActionsVariables()).thenCallRealMethod();
             when(mock.getMavenRepositoryUrl()).thenReturn("http://localhost:8081/artifactory/libs-release-local");
             when(mock.getDeployerUsername()).thenReturn("ci-deployer");
             when(mock.getDeployerPassword()).thenReturn("ci-deployer-password");
@@ -63,10 +65,21 @@ class ArtifactoryTestExtensionUnitTest {
             ArtifactoryContainer container = construction.constructed().get(0);
             verify(container).start();
 
+            assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL))
+                    .isEqualTo("http://host.testcontainers.internal:8081/artifactory");
+            assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY))
+                    .isEqualTo("libs-release-local");
+            assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME))
+                    .isEqualTo("ci-deployer");
+            assertThat(System.getProperty(ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD))
+                    .isEqualTo("ci-deployer-password");
             assertThat(System.getProperty("artifactory.url")).isEqualTo("http://localhost:8081/artifactory");
             assertThat(System.getProperty("artifactory.maven.repository.url")).isEqualTo("http://localhost:8081/artifactory/libs-release-local");
             assertThat(System.getProperty("artifactory.deployer.username")).isEqualTo("ci-deployer");
             assertThat(System.getProperty("artifactory.deployer.password")).isEqualTo("ci-deployer-password");
+            assertThat(System.getProperty("REPO_REMOTE_URL")).isNull();
+            assertThat(System.getProperty("REPO_REMOTE_USERNAME")).isNull();
+            assertThat(System.getProperty("REPO_REMOTE_TOKEN")).isNull();
         }
     }
 
@@ -111,6 +124,7 @@ class ArtifactoryTestExtensionUnitTest {
     }
 
     private static void stubContainerDefaults(ArtifactoryContainer container) {
+        when(container.standardActionsVariables()).thenCallRealMethod();
         when(container.getMavenRepositoryUrl()).thenReturn("http://localhost:8081/artifactory/libs-release-local");
         when(container.getDeployerUsername()).thenReturn("ci-deployer");
         when(container.getDeployerPassword()).thenReturn("ci-deployer-password");

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaWithArtifactoryAnnotationIntegrationTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaWithArtifactoryAnnotationIntegrationTest.java
@@ -21,4 +21,27 @@ class GiteaWithArtifactoryAnnotationIntegrationTest {
         assertThat(artifactory.getApiUrl()).isNotBlank();
         assertThat(System.getProperty("artifactory.url")).isEqualTo(artifactory.getApiUrl());
     }
+
+    @Test
+    @DisplayName("Artifactory should configure the standard Actions variable contract in Gitea")
+    void shouldConfigureRepositoryActionsVariables(GiteaContainer gitea, ArtifactoryContainer artifactory) {
+        String repoOwner = gitea.getAdminUsername();
+        String repoName = "integration-repo";
+
+        gitea.waitForRepository(repoName);
+        artifactory.configureRepositoryActionsVariables(gitea, repoOwner, repoName);
+
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL))
+                .isEqualTo(artifactory.getRunnerAccessibleApiUrl());
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY))
+                .isEqualTo(artifactory.getMavenRepositoryName());
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME))
+                .isEqualTo(artifactory.getDeployerUsername());
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD))
+                .isEqualTo(artifactory.getDeployerPassword());
+    }
 }


### PR DESCRIPTION
## Summary
- define a first-class `ARTIFACTORY_*` Actions contract on the Artifactory harness
- publish that contract as default system properties and remove unrelated `REPO_REMOTE_*` wiring from the Artifactory extension
- document and test direct Gitea repository variable provisioning for downstream workflow repos

## Testing
- ./mvnw -Dtest=ArtifactoryContainerContractTest,ArtifactoryTestExtensionUnitTest,ArtifactoryAnnotationIntegrationTest,GiteaWithArtifactoryAnnotationIntegrationTest test

Closes #30