### PR TITLE
Provide default Artifactory repo vars for Gitea Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ artifactory.configureRepositoryActionsVariables(gitea, gitea.getAdminUsername(),
 The existing `artifactory.*` system properties remain available for host-side
 test code that talks to Artifactory directly.
 
+When both harnesses are active, calling `gitea.enableRepositoryActions(owner, repo)`
+will also provision those same `ARTIFACTORY_*` values as default repository Actions
+variables for that repo. Existing values are left alone, so explicit
+`gitea.ensureRepositoryActionsVariable(...)` calls can still override or remove them.
+
 ## Gitea Actions support
 
 `GiteaContainer` exposes a lightweight Actions facade for inspecting workflow runs and logs:

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsSupport.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsSupport.java
@@ -62,6 +62,24 @@ final class GiteaActionsSupport {
         }
     }
 
+    void ensureRepositoryActionsVariableIfAbsent(String repoOwner, String repoName, String variableName, String value) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+
+        String variablesBase = actionsVariablesBase(repoOwner, repoName);
+        Duration timeout = ACTION_VARIABLE_RETRY_DELAY.multipliedBy(ACTION_VARIABLE_CREATE_ATTEMPTS);
+        try {
+            Awaitility.await("actions variable " + variableName + " to exist without overriding explicit values")
+                    .pollInterval(ACTION_VARIABLE_RETRY_DELAY)
+                    .atMost(timeout)
+                    .ignoreExceptions()
+                    .until(() -> ensureRepositoryActionsVariableIfAbsentAttempt(variablesBase, variableName, value));
+        } catch (ConditionTimeoutException e) {
+            throw new IllegalStateException("Timed out configuring default repository variable '" + variableName + "'", e);
+        }
+    }
+
 
     private void ensureRepositoryActionsVariableAbsent(String variablesBase, String variableName) {
         Duration timeout = ACTION_VARIABLE_RETRY_DELAY.multipliedBy(ACTION_VARIABLE_CREATE_ATTEMPTS);
@@ -85,6 +103,17 @@ final class GiteaActionsSupport {
             return deleteActionsVariable(variablesBase, variableName);
         }
         throw new IllegalStateException("Unexpected status when probing repository variable '" + variableName + "': HTTP " + status);
+    }
+
+    private boolean ensureRepositoryActionsVariableIfAbsentAttempt(String variablesBase, String variableName, String value) {
+        int status = getActionsVariableStatus(variablesBase, variableName);
+        if (status == 200) {
+            return true;
+        }
+        if (status == 404 || status == 405 || status == 503) {
+            return createActionsVariable(variablesBase, variableName, value);
+        }
+        throw new IllegalStateException("Unexpected status when probing default repository variable '" + variableName + "': HTTP " + status);
     }
 
     private boolean deleteActionsVariable(String variablesBase, String variableName) {

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Frame;
+import dev.promptlm.testutils.artifactory.ArtifactoryContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.awaitility.Awaitility;
@@ -30,6 +31,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -226,6 +228,18 @@ public class GiteaContainer {
      */
     public void ensureRepositoryActionsVariable(String repoOwner, String repoName, String variableName, String value) {
         actionsSupport.ensureRepositoryActionsVariable(repoOwner, repoName, variableName, value);
+    }
+
+    /**
+     * Create a repository Actions variable only when it does not already exist.
+     *
+     * @param repoOwner repository owner
+     * @param repoName repository name
+     * @param variableName variable key
+     * @param value desired default value
+     */
+    public void ensureRepositoryActionsVariableIfAbsent(String repoOwner, String repoName, String variableName, String value) {
+        actionsSupport.ensureRepositoryActionsVariableIfAbsent(repoOwner, repoName, variableName, value);
     }
 
     /**
@@ -1029,6 +1043,35 @@ public class GiteaContainer {
      */
     public void enableRepositoryActions(String repoOwner, String repoName) {
         actionsSupport.enableRepositoryActions(repoOwner, repoName);
+        provisionDefaultArtifactoryActionsVariables(repoOwner, repoName);
+    }
+
+    private void provisionDefaultArtifactoryActionsVariables(String repoOwner, String repoName) {
+        Map<String, String> defaultVariables = defaultArtifactoryActionsVariablesFromSystemProperties();
+        if (defaultVariables.isEmpty()) {
+            return;
+        }
+
+        defaultVariables.forEach((key, value) ->
+                ensureRepositoryActionsVariableIfAbsent(repoOwner, repoName, key, value));
+        logger.info("Provisioned {} default Artifactory Actions variable(s) for {}/{}",
+                defaultVariables.size(), repoOwner, repoName);
+    }
+
+    private Map<String, String> defaultArtifactoryActionsVariablesFromSystemProperties() {
+        Map<String, String> variables = new LinkedHashMap<>();
+        putSystemPropertyIfPresent(variables, ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL);
+        putSystemPropertyIfPresent(variables, ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY);
+        putSystemPropertyIfPresent(variables, ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME);
+        putSystemPropertyIfPresent(variables, ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD);
+        return variables;
+    }
+
+    private void putSystemPropertyIfPresent(Map<String, String> variables, String propertyName) {
+        String value = System.getProperty(propertyName);
+        if (!isBlank(value)) {
+            variables.put(propertyName, value);
+        }
     }
 
     /**

--- a/src/test/java/dev/promptlm/testutils/CiWorkflowHarnessTest.java
+++ b/src/test/java/dev/promptlm/testutils/CiWorkflowHarnessTest.java
@@ -53,7 +53,6 @@ class CiWorkflowHarnessTest {
 
         String version = "1.0.0-" + System.currentTimeMillis();
         String owner = gitea.getAdminUsername();
-        String deployRepositoryUrl = artifactory.getRunnerAccessibleApiUrl() + "/" + artifactory.getMavenRepositoryName();
         String runnerCloneUrl = "http://localhost.localtest.me:%d/%s/%s.git".formatted(
                 URI.create(gitea.getWebUrl()).getPort(),
                 owner,
@@ -65,7 +64,7 @@ class CiWorkflowHarnessTest {
 
         Path repositoryDir = tempDir.resolve(REPO_NAME);
         Files.createDirectories(repositoryDir);
-        writeWorkflowProject(repositoryDir, version, artifactory, deployRepositoryUrl, runnerCloneUrl, gitea);
+        writeWorkflowProject(repositoryDir, version, runnerCloneUrl, gitea);
 
         String commitSha = seedRepository(repositoryDir, gitea, owner);
 
@@ -146,8 +145,6 @@ class CiWorkflowHarnessTest {
 
     private void writeWorkflowProject(Path repositoryDir,
                                       String version,
-                                      ArtifactoryContainer artifactory,
-                                      String deployRepositoryUrl,
                                       String runnerCloneUrl,
                                       GiteaContainer gitea) throws IOException {
         Files.createDirectories(repositoryDir.resolve(".gitea/workflows"));
@@ -157,12 +154,9 @@ class CiWorkflowHarnessTest {
                 "GROUP_ID", GROUP_ID,
                 "ARTIFACT_ID", ARTIFACT_ID,
                 "VERSION", version,
-                "DEPLOY_REPOSITORY_URL", deployRepositoryUrl,
                 "REPO_CLONE_URL", runnerCloneUrl,
                 "REPO_CLONE_USERNAME", gitea.getAdminUsername(),
-                "REPO_CLONE_TOKEN", gitea.getAdminToken(),
-                "ARTIFACTORY_USERNAME", artifactory.getDeployerUsername(),
-                "ARTIFACTORY_PASSWORD", artifactory.getDeployerPassword());
+                "REPO_CLONE_TOKEN", gitea.getAdminToken());
 
         writeTemplate("dev/promptlm/testutils/ciworkflow/pom.xml.template",
                 repositoryDir.resolve("pom.xml"),

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaWithArtifactoryAnnotationIntegrationTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaWithArtifactoryAnnotationIntegrationTest.java
@@ -26,8 +26,9 @@ class GiteaWithArtifactoryAnnotationIntegrationTest {
     @DisplayName("Artifactory should configure the standard Actions variable contract in Gitea")
     void shouldConfigureRepositoryActionsVariables(GiteaContainer gitea, ArtifactoryContainer artifactory) {
         String repoOwner = gitea.getAdminUsername();
-        String repoName = "integration-repo";
+        String repoName = "manual-artifactory-vars-repo";
 
+        gitea.createRepository(repoName);
         gitea.waitForRepository(repoName);
         artifactory.configureRepositoryActionsVariables(gitea, repoOwner, repoName);
 
@@ -43,5 +44,48 @@ class GiteaWithArtifactoryAnnotationIntegrationTest {
         assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
                 ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD))
                 .isEqualTo(artifactory.getDeployerPassword());
+    }
+
+    @Test
+    @DisplayName("Enabling repository Actions should provision default Artifactory workflow variables")
+    void shouldProvisionDefaultArtifactoryVariablesWhenEnablingActions(GiteaContainer gitea,
+                                                                       ArtifactoryContainer artifactory) {
+        String repoOwner = gitea.getAdminUsername();
+        String repoName = "default-artifactory-vars-repo";
+
+        gitea.createRepository(repoName);
+        gitea.waitForRepository(repoName);
+        gitea.enableRepositoryActions(repoOwner, repoName);
+
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_URL))
+                .isEqualTo(artifactory.getRunnerAccessibleApiUrl());
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY))
+                .isEqualTo(artifactory.getMavenRepositoryName());
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_USERNAME))
+                .isEqualTo(artifactory.getDeployerUsername());
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_PASSWORD))
+                .isEqualTo(artifactory.getDeployerPassword());
+    }
+
+    @Test
+    @DisplayName("Explicit Artifactory workflow variable overrides should win over defaults")
+    void explicitOverridesShouldWinOverDefaultProvisioning(GiteaContainer gitea) {
+        String repoOwner = gitea.getAdminUsername();
+        String repoName = "override-artifactory-vars-repo";
+
+        gitea.createRepository(repoName);
+        gitea.waitForRepository(repoName);
+        gitea.enableRepositoryActions(repoOwner, repoName);
+        gitea.ensureRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY, "custom-release-local");
+        gitea.enableRepositoryActions(repoOwner, repoName);
+
+        assertThat(gitea.readRepositoryActionsVariable(repoOwner, repoName,
+                ArtifactoryContainer.ACTIONS_VARIABLE_ARTIFACTORY_REPOSITORY))
+                .isEqualTo("custom-release-local");
     }
 }

--- a/src/test/resources/dev/promptlm/testutils/ciworkflow/deploy-artifactory.yml.template
+++ b/src/test/resources/dev/promptlm/testutils/ciworkflow/deploy-artifactory.yml.template
@@ -5,12 +5,13 @@ on:
       - main
 
 env:
-  DEPLOY_REPOSITORY_URL: "{{DEPLOY_REPOSITORY_URL}}"
   REPO_CLONE_URL: "{{REPO_CLONE_URL}}"
   REPO_CLONE_USERNAME: "{{REPO_CLONE_USERNAME}}"
   REPO_CLONE_TOKEN: "{{REPO_CLONE_TOKEN}}"
-  ARTIFACTORY_USERNAME: "{{ARTIFACTORY_USERNAME}}"
-  ARTIFACTORY_PASSWORD: "{{ARTIFACTORY_PASSWORD}}"
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+  ARTIFACTORY_REPOSITORY: ${{ vars.ARTIFACTORY_REPOSITORY }}
+  ARTIFACTORY_USERNAME: ${{ vars.ARTIFACTORY_USERNAME }}
+  ARTIFACTORY_PASSWORD: ${{ vars.ARTIFACTORY_PASSWORD }}
 
 jobs:
   deploy:
@@ -35,5 +36,6 @@ jobs:
             </servers>
           </settings>
           EOF
+          DEPLOY_REPOSITORY_URL="${ARTIFACTORY_URL%/}/${ARTIFACTORY_REPOSITORY}"
           mvn -B -ntp deploy -DskipTests \
             -DaltDeploymentRepository=artifactory::default::${DEPLOY_REPOSITORY_URL}


### PR DESCRIPTION
## Summary
- provision default `ARTIFACTORY_*` repository Actions variables when `enableRepositoryActions(...)` runs and Artifactory defaults are available
- preserve explicit overrides by only creating missing variables instead of overwriting existing ones
- update the workflow harness and docs to rely on repository variables for the happy path

## Testing
- ./mvnw -Dtest=GiteaWithArtifactoryAnnotationIntegrationTest,CiWorkflowHarnessTest test

Closes #32