### PR TITLE
fix: make release reruns recover after Central publish

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -53,6 +53,19 @@ jobs:
             echo "release_version $RELEASE_VERSION must be greater than current version $CURRENT_BASE."
             exit 1
           fi
+          TAG="v${RELEASE_VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Release tag ${TAG} already exists on origin. Rerun the Release workflow for that tag instead of preparing a new release PR."
+            exit 1
+          fi
+          GROUP_ID="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.groupId)"
+          ARTIFACT_ID="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.artifactId)"
+          GROUP_PATH="$(printf '%s' "$GROUP_ID" | tr '.' '/')"
+          ARTIFACT_URL="https://repo.maven.apache.org/maven2/${GROUP_PATH}/${ARTIFACT_ID}/${RELEASE_VERSION}/${ARTIFACT_ID}-${RELEASE_VERSION}.pom"
+          if curl --silent --fail --head "$ARTIFACT_URL" >/dev/null; then
+            echo "Release ${GROUP_ID}:${ARTIFACT_ID}:${RELEASE_VERSION} is already published on Maven Central. Rerun the Release workflow for tag ${TAG} only if you need to recover post-release steps."
+            exit 1
+          fi
 
       - name: Set release version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
         description: "Milestone title (defaults to version without v)"
         required: false
 
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -115,10 +119,27 @@ jobs:
             exit 1
           fi
 
+      - name: Check Maven Central for an existing release
+        id: central
+        run: |
+          set -euo pipefail
+          GROUP_ID="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.groupId)"
+          ARTIFACT_ID="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.artifactId)"
+          VERSION="${{ steps.release.outputs.version }}"
+          GROUP_PATH="$(printf '%s' "$GROUP_ID" | tr '.' '/')"
+          ARTIFACT_URL="https://repo.maven.apache.org/maven2/${GROUP_PATH}/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}.pom"
+          if curl --silent --fail --head "$ARTIFACT_URL" >/dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Release ${GROUP_ID}:${ARTIFACT_ID}:${VERSION} is already published on Maven Central; skipping deploy."
+            exit 0
+          fi
+          echo "published=false" >> "$GITHUB_OUTPUT"
+
       - name: Build and test
         run: ./mvnw -B clean verify
 
       - name: Deploy to Maven Central (Central Portal)
+        if: ${{ steps.central.outputs.published != 'true' }}
         run: ./mvnw -B -Prelease -DskipTests -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}" deploy
 
       - name: Resolve next development version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,8 @@ This document describes how to cut a release using GitHub Actions and the Spring
 2. Assign PRs/issues to the milestone and apply labels for sections.
 3. Run the **Prepare Release** workflow with `release_version` (e.g. `1.1.7`).
    - This validates the version is greater than the current one,
-     updates `pom.xml`, and opens a PR labeled `release`.
+     refuses already-tagged or already-published versions, updates `pom.xml`,
+     and opens a PR labeled `release`.
    - If auto-merge is enabled, the PR merges when checks pass.
 4. When the release PR merges, the **Tag Release** workflow tags `v<version>`.
 5. Tag creation triggers the **Release** workflow (or you can run it manually), which will:
@@ -17,6 +18,7 @@ This document describes how to cut a release using GitHub Actions and the Spring
    - open a PR that bumps `main` to the next patch `-SNAPSHOT` version and enables auto-merge
    - generate release notes from the milestone
    - create the GitHub Release
+   - skip the deploy step on reruns if the version is already on Maven Central, so the workflow can recover post-release steps after a partial success
 
 ## Snapshots
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
+        <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
         <central.publishing.plugin.version>0.10.0</central.publishing.plugin.version>
     </properties>
@@ -246,6 +247,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-deploy-plugin</artifactId>
+                        <version>${maven.deploy.plugin.version}</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>


### PR DESCRIPTION
## Summary
- skip the Central deploy step on reruns when the release version is already published
- block `Prepare Release` from reopening an already-tagged or already-published version
- pin `maven-deploy-plugin` and document the partial-success recovery path

## Why
The `v1.2.0` release uploaded successfully to Maven Central, but a later rerun tried to publish the same immutable coordinates again and failed with:

```text
Component with package url: 'pkg:maven/dev.promptlm.test/junit-gitea-artifactory@1.2.0' already exists
```

That aborts the workflow before it can open the post-release `-SNAPSHOT` bump PR, leaving `main` pinned to the release commit.

## Validation
- `git diff --check`
- YAML parse for `.github/workflows/release.yml` and `.github/workflows/prepare-release.yml`
- `./mvnw -B -q -Prelease -DskipTests validate`
- confirmed `dev.promptlm.test:junit-gitea-artifactory:1.2.0` already exists on Maven Central

## Recovery
After merging this PR, manually run the `Release` workflow with `tag=v1.2.0` from the updated `main` branch. The workflow should skip the Central deploy and continue with the post-release steps.
