### PR TITLE
fix: align published Jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,9 @@
         <testcontainers.version>2.0.3</testcontainers.version>
         <awaitility.version>4.3.0</awaitility.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <jackson.version>2.21.1</jackson.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
+        <jackson.core.version>2.21.1</jackson.core.version>
+        <jackson.databind.version>2.21.1</jackson.databind.version>
         <mockito.version>5.23.0</mockito.version>
         <bytebuddy.version>1.18.7</bytebuddy.version>
         <zstd.version>1.5.7-7</zstd.version>
@@ -98,8 +100,20 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.annotations.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.core.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- publish jackson-annotations, jackson-core, and jackson-databind as explicit compile dependencies
- use the published Jackson versions available on Maven Central (`jackson-annotations` 2.21, `jackson-core`/`jackson-databind` 2.21.1)
- avoid consumers resolving only `jackson-databind` directly and ending up with an older transitive annotations jar

## Verification
- `./mvnw -q -DskipTests package`
- `./mvnw dependency:tree -Dincludes=com.fasterxml.jackson.core`

Closes #40