### PR TITLE
Make runner image annotation-configurable and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ var report = actions.waitForWorkflowRunBySha("owner", "repo", "commitSha",
         Duration.ofMinutes(2), Duration.ofSeconds(2));
 ```
 
+Enable Actions from the annotation and optionally choose the runner image per test class:
+
+```java
+@WithGitea(
+        actionsEnabled = true,
+        runnerImage = "docker.io/gitea/act_runner:0.2.11",
+        createTestRepos = true,
+        testRepoNames = {"demo"})
+class ActionsIntegrationTest {
+}
+```
+
+If `runnerImage` is omitted or blank, the default runner image is used.
+
 When Actions workflows time out, the container can collect diagnostics (runs, jobs, logs)
 to aid troubleshooting.
 

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
@@ -55,8 +55,7 @@ public class GiteaContainer {
     private static final String GITEA_IMAGE = resolveImage("gitea.image", "GITEA_IMAGE",
             "docker.gitea.com/gitea:1.25.4-rootless");
     private static final int GITEA_PORT = 3000;
-    private static final String GITEA_RUNNER_IMAGE = resolveImage("gitea.runner.image", "GITEA_RUNNER_IMAGE",
-            "docker.io/gitea/act_runner:0.2.11");
+    private static final String DEFAULT_GITEA_RUNNER_IMAGE = "docker.io/gitea/act_runner:0.2.11";
     private static final String RUNNER_NAME = "gitea-runner";
     private static final String DOCKER_IMAGE_LABEL = resolveImage("gitea.actions.job.image", "GITEA_ACTIONS_JOB_IMAGE",
             "docker://ghcr.io/catthehacker/ubuntu:act-22.04");
@@ -103,6 +102,7 @@ public class GiteaContainer {
     private String adminEmail = "test@example.com";
     private String adminToken;
     private boolean actionsEnabled;
+    private String runnerImage = DEFAULT_GITEA_RUNNER_IMAGE;
     private String runnerRegistrationToken;
     private final String traceId = UUID.randomUUID().toString();
     private final GiteaApiClient apiClient;
@@ -459,6 +459,19 @@ public class GiteaContainer {
         return this;
     }
 
+    /**
+     * Configure the Docker image used for the Actions runner.
+     * <p>
+     * Must be called before {@link #start()}.
+     *
+     * @param image Docker image reference, for example {@code docker.io/gitea/act_runner:0.2.11}
+     * @return this container instance
+     */
+    public GiteaContainer withRunnerImage(String image) {
+        this.runnerImage = isBlank(image) ? DEFAULT_GITEA_RUNNER_IMAGE : image.trim();
+        return this;
+    }
+
     private String buildInternalInstanceUrl() {
         return "http://" + RUNNER_ACCESSIBLE_HOST + ":" + fixedHttpPort;
     }
@@ -616,7 +629,7 @@ public class GiteaContainer {
 
             writeRunnerConfig(RUNNER_NAME);
 
-            this.runner = new GenericContainer<>(DockerImageName.parse(GITEA_RUNNER_IMAGE))
+            this.runner = new GenericContainer<>(DockerImageName.parse(runnerImage))
                     .withEnv("CONFIG_FILE", "/data/config.yaml")
                     .withEnv("GITEA_INSTANCE_URL", buildInternalInstanceUrl())
                     .withEnv("GITEA_RUNNER_REGISTRATION_TOKEN", token)

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaTestExtension.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaTestExtension.java
@@ -97,7 +97,8 @@ class GiteaTestExtension implements BeforeAllCallback, AfterAllCallback, Paramet
 
         GiteaContainer giteaContainer = new GiteaContainer()
                 .withAdminUser(adminUsername, adminPassword, adminEmail)
-                .withActionsEnabled(annotation.actionsEnabled());
+                .withActionsEnabled(annotation.actionsEnabled())
+                .withRunnerImage(annotation.runnerImage());
 
         try {
             giteaContainer.start();

--- a/src/main/java/dev/promptlm/testutils/gitea/WithGitea.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/WithGitea.java
@@ -88,4 +88,13 @@ public @interface WithGitea {
      * @return {@code true} to start the Actions runner
      */
     boolean actionsEnabled() default false;
+
+    /**
+     * Docker image to use for the Actions runner.
+     * <p>
+     * Only applied when {@link #actionsEnabled()} is {@code true}. Leave blank to use the default image.
+     *
+     * @return Actions runner image reference
+     */
+    String runnerImage() default "";
 }

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaTestExtensionUnitTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaTestExtensionUnitTest.java
@@ -48,6 +48,7 @@ class GiteaTestExtensionUnitTest {
         try (MockedConstruction<GiteaContainer> construction = mockConstruction(GiteaContainer.class, (mock, c) -> {
             when(mock.withAdminUser(anyString(), anyString(), anyString())).thenReturn(mock);
             when(mock.withActionsEnabled(anyBoolean())).thenReturn(mock);
+            when(mock.withRunnerImage(anyString())).thenReturn(mock);
             when(mock.getApiUrl()).thenReturn("http://localhost:39999/api/v1");
             when(mock.getAdminUsername()).thenReturn("testuser");
             when(mock.getAdminToken()).thenReturn("token-123");
@@ -78,6 +79,7 @@ class GiteaTestExtensionUnitTest {
         try (MockedConstruction<GiteaContainer> construction = mockConstruction(GiteaContainer.class, (mock, c) -> {
             when(mock.withAdminUser(anyString(), anyString(), anyString())).thenReturn(mock);
             when(mock.withActionsEnabled(anyBoolean())).thenReturn(mock);
+            when(mock.withRunnerImage(anyString())).thenReturn(mock);
             when(mock.getApiUrl()).thenReturn("http://localhost:39999/api/v1");
             when(mock.getAdminUsername()).thenReturn("alias-user");
             when(mock.getAdminToken()).thenReturn("token-123");
@@ -123,10 +125,33 @@ class GiteaTestExtensionUnitTest {
         try (MockedConstruction<GiteaContainer> construction = mockConstruction(GiteaContainer.class, (mock, c) -> {
             when(mock.withAdminUser(anyString(), anyString(), anyString())).thenReturn(mock);
             when(mock.withActionsEnabled(anyBoolean())).thenReturn(mock);
+            when(mock.withRunnerImage(anyString())).thenReturn(mock);
             org.mockito.Mockito.doThrow(new IllegalStateException("docker unavailable")).when(mock).start();
         })) {
             assertThatThrownBy(() -> extension.beforeAll(context)).isInstanceOf(TestAbortedException.class);
             verify(store, never()).put(eq(containerKey(AnnotatedDefaultTest.class)), any());
+        }
+    }
+
+    @Test
+    void forwardsRunnerImageFromAnnotation() {
+        ExtensionContext context = extensionContextFor(AnnotatedWithRunnerImageTest.class);
+        ExtensionContext.Store store = mock(ExtensionContext.Store.class);
+        when(context.getStore(any())).thenReturn(store);
+
+        try (MockedConstruction<GiteaContainer> construction = mockConstruction(GiteaContainer.class, (mock, c) -> {
+            when(mock.withAdminUser(anyString(), anyString(), anyString())).thenReturn(mock);
+            when(mock.withActionsEnabled(anyBoolean())).thenReturn(mock);
+            when(mock.withRunnerImage(anyString())).thenReturn(mock);
+            when(mock.getApiUrl()).thenReturn("http://localhost:39999/api/v1");
+            when(mock.getAdminUsername()).thenReturn("testuser");
+            when(mock.getAdminToken()).thenReturn("token-123");
+            when(mock.getWebUrl()).thenReturn("http://localhost:39999");
+        })) {
+            extension.beforeAll(context);
+
+            GiteaContainer container = construction.constructed().get(0);
+            verify(container).withRunnerImage(eq("docker.io/gitea/act_runner:0.2.11"));
         }
     }
 
@@ -230,6 +255,10 @@ class GiteaTestExtensionUnitTest {
 
     @WithGitea(username = "alias-user", password = "alias-pass", adminEmail = "alias@example.com")
     static class AnnotatedWithAliasCredentialsTest {
+    }
+
+    @WithGitea(actionsEnabled = true, runnerImage = "docker.io/gitea/act_runner:0.2.11")
+    static class AnnotatedWithRunnerImageTest {
     }
 
     @WithGitea


### PR DESCRIPTION
## Summary
- remove runner image env/property override path and use per-container runner image configuration
- add runnerImage to @WithGitea and wire it through GiteaTestExtension
- document annotation-based runner image configuration in README

## Testing
- ./mvnw -q -Dtest=GiteaTestExtensionUnitTest test