### PR TITLE
feat(docker): auto-apply DockerAvailableExtension via @WithGitea/@WithArtifactory

### DIFF
--- a/src/main/java/dev/promptlm/testutils/artifactory/WithArtifactory.java
+++ b/src/main/java/dev/promptlm/testutils/artifactory/WithArtifactory.java
@@ -1,5 +1,6 @@
 package dev.promptlm.testutils.artifactory;
 
+import dev.promptlm.testutils.docker.DockerAvailableExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.ElementType;
@@ -22,7 +23,10 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(ArtifactoryTestExtension.class)
+// DockerAvailableExtension first: pings Docker with a 5s cap and skips the
+// test class with an actionable remediation hint if the daemon is unreachable,
+// instead of timing out deep inside ArtifactoryContainer.start().
+@ExtendWith({DockerAvailableExtension.class, ArtifactoryTestExtension.class})
 public @interface WithArtifactory {
     
     /**

--- a/src/main/java/dev/promptlm/testutils/docker/DockerAvailableExtension.java
+++ b/src/main/java/dev/promptlm/testutils/docker/DockerAvailableExtension.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.testutils.docker;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Fail-fast precondition for Testcontainers-backed tests.
+ *
+ * <p>Pings the Docker daemon before any {@code @WithGitea} / {@code @WithArtifactory}
+ * container starts. If Docker is unreachable, the test class is <em>skipped</em>
+ * via {@link Assumptions} with an actionable remediation hint, instead of
+ * timing out ~4 minutes into container init with a confusing Testcontainers
+ * stack trace.
+ *
+ * <p>Wired automatically by {@code @WithGitea} and {@code @WithArtifactory} —
+ * consumers do not need to add {@code @ExtendWith(DockerAvailableExtension.class)}
+ * themselves. The ping has a 5-second hard cap and uses
+ * {@link DockerClientFactory} so the check honours the same socket discovery
+ * logic Testcontainers itself will use.
+ */
+public final class DockerAvailableExtension implements BeforeAllCallback {
+
+    private static final Logger log = LoggerFactory.getLogger(DockerAvailableExtension.class);
+
+    private static final long PING_TIMEOUT_SECONDS = 5;
+
+    private static final String REMEDIATION_HINT = """
+            Docker is not reachable from this JVM. Tests using @WithGitea / @WithArtifactory \
+            need a working Docker daemon for Testcontainers.
+
+            To diagnose:
+              docker info
+
+            If you see "Cannot connect to the Docker daemon at unix:///var/run/docker.sock", \
+            create the symlink:
+              sudo ln -sf "$HOME/.docker/run/docker.sock" /var/run/docker.sock
+
+            Then re-run the test.
+            Cause: %s""";
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        CompletableFuture<Void> ping = CompletableFuture.runAsync(() ->
+                DockerClientFactory.instance().client().pingCmd().exec());
+        try {
+            ping.get(PING_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            log.debug("Docker daemon reachable; proceeding with Testcontainers-backed test {}",
+                    context.getDisplayName());
+        }
+        catch (TimeoutException ex) {
+            ping.cancel(true);
+            skip("ping timed out after " + PING_TIMEOUT_SECONDS + "s");
+        }
+        catch (ExecutionException ex) {
+            Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+            skip(cause.getClass().getSimpleName() + ": " + cause.getMessage());
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            skip("interrupted while waiting for Docker ping");
+        }
+    }
+
+    private static void skip(String cause) {
+        Assumptions.assumeTrue(false, REMEDIATION_HINT.formatted(cause));
+    }
+}

--- a/src/main/java/dev/promptlm/testutils/gitea/WithGitea.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/WithGitea.java
@@ -1,5 +1,6 @@
 package dev.promptlm.testutils.gitea;
 
+import dev.promptlm.testutils.docker.DockerAvailableExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.ElementType;
@@ -30,7 +31,10 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(GiteaTestExtension.class)
+// DockerAvailableExtension first: pings Docker with a 5s cap and skips the
+// test class with an actionable remediation hint if the daemon is unreachable,
+// instead of timing out ~4 minutes into GiteaTestExtension's container init.
+@ExtendWith({DockerAvailableExtension.class, GiteaTestExtension.class})
 public @interface WithGitea {
 
     /**


### PR DESCRIPTION
## Summary

Lifts the fail-fast Docker-availability precondition out of `promptLM/promptlm-app#273` (acceptance-tests only) and into the testkit, where every consumer of `@WithGitea` / `@WithArtifactory` gets it for free.

## What

- `dev.promptlm.testutils.docker.DockerAvailableExtension` — JUnit Jupiter `BeforeAllCallback` that pings `DockerClientFactory.instance().client().pingCmd().exec()` inside a `CompletableFuture` with a 5-second hard cap. On timeout / connection error / interruption it calls `Assumptions.assumeTrue(false, ...)` with this remediation hint:

  ```
  Docker is not reachable from this JVM. Tests using @WithGitea / @WithArtifactory need a working Docker daemon for Testcontainers.

  To diagnose:
    docker info

  If you see "Cannot connect to the Docker daemon at unix:///var/run/docker.sock", create the symlink:
    sudo ln -sf "$HOME/.docker/run/docker.sock" /var/run/docker.sock

  Then re-run the test.
  Cause: <original throwable>
  ```

- `@WithGitea` and `@WithArtifactory` now declare `@ExtendWith({DockerAvailableExtension.class, <existing>.class})` so the precondition runs **before** the container-starting extension. Consumers do not need to add `@ExtendWith(DockerAvailableExtension.class)` themselves.

## Why

Without the precondition, tests time out ~4 minutes into container init with a confusing Testcontainers stack trace. The most common cause on macOS — `/var/run/docker.sock` symlinked to the wrong path after a Docker Desktop reinstall — is one `sudo ln -sf` away from fixed, and the remediation hint points right at it.

## Supersedes

- promptLM/promptlm-app#273 — same extension lived under `acceptance-tests/src/test/java/dev/promptlm/test/support/`. Once this PR ships and `promptlm-app` picks up the new testkit version, that PR can be closed: the 6 `@ExtendWith(DockerAvailableExtension.class)` registrations across `HappyPathUserJourneyTest`, `CiWorkflowHarnessTest`, `BackendFacadeInfraE2eTest`, `CliAcceptanceTests`, `NativeCliSmokeTest`, `NativeWebappUiSmokeTest` become no-ops (auto-applied) and can be deleted in a follow-up cleanup.

## Test plan

- [x] `mvn -B -DskipTests compile` — green.
- [ ] Bump testkit version in promptlm-app, verify a deliberately-broken `/var/run/docker.sock` triggers the skip with the right message (no longer the 4-minute Testcontainers timeout).