### PR TITLE
Fix Actions workflow/build state reporting + remove broken sqlite3-based checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@
 # OS/files
 .DS_Store
 *.log
+
+# Claude Code agent state and scratch artifacts.
+# Issue-delivery artefacts (.claude/issue-delivery/) are local-only by default
+# per .claude/commands/github-issue-delivery/PROCEDURE.md — the PR description
+# is the durable record. Repos that want the audit trail committed should
+# remove or scope this rule.
+/.claude/

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActions.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActions.java
@@ -157,8 +157,12 @@ public final class GiteaActions {
                     .until(() -> findTerminalRun(repoOwner, repoName, normalizedSha), Objects::nonNull);
         } catch (ConditionTimeoutException e) {
             GiteaActionsDiagnostics diagnostics = collectDiagnostics(repoOwner, repoName);
-            throw new GiteaWorkflowException("Timed out waiting for workflow run for " + repoOwner + "/" + repoName
-                    + " sha=" + normalizedSha, e, diagnostics);
+            String baseMessage = "Timed out waiting for workflow run for " + repoOwner + "/" + repoName
+                    + " sha=" + normalizedSha;
+            String message = diagnostics == null
+                    ? baseMessage
+                    : baseMessage + System.lineSeparator() + diagnostics.summary();
+            throw new GiteaWorkflowException(message, e, diagnostics);
         }
     }
 

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnostics.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnostics.java
@@ -1,8 +1,11 @@
 package dev.promptlm.testutils.gitea;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Structured snapshot of Actions-related diagnostics collected from a Gitea test harness.
@@ -36,4 +39,189 @@ public record GiteaActionsDiagnostics(String traceId,
                                      String runnerLogs,
                                      String giteaLogs,
                                      List<String> warnings) {
+
+    /** Maximum number of most-recent runs surfaced by {@link #summary()}. */
+    public static final int SUMMARY_MAX_RUNS = 5;
+
+    /** Maximum number of jobs per run surfaced by {@link #summary()}. */
+    public static final int SUMMARY_MAX_JOBS_PER_RUN = 5;
+
+    /** Maximum number of warning messages surfaced by {@link #summary()}. */
+    public static final int SUMMARY_MAX_WARNINGS = 3;
+
+    /** Length of the SHA prefix shown in the summary. */
+    public static final int SUMMARY_SHA_PREFIX_LEN = 8;
+
+    /**
+     * Render a redacted, human-readable summary of this diagnostics snapshot suitable for
+     * surfacing in exception messages and log lines.
+     *
+     * <p>The summary selects fields explicitly: trace id, repo identity, workflow file names,
+     * and per-run + per-job state. It never includes raw log content
+     * ({@link #jobLogsByJobId()}, {@link #runnerLogs()}, {@link #giteaLogs()},
+     * {@link #taskContainerLogsByJobId()}, {@link #giteaActionsLogFiles()}), because those can
+     * carry caller-supplied secrets, the runner registration token, or HTTP authorization
+     * header echoes. Callers that want raw logs must access them via the explicit getters on
+     * the record — making secret promotion into log lines an opt-in decision.
+     *
+     * <p>Output is bounded: at most {@value #SUMMARY_MAX_RUNS} most-recent runs,
+     * {@value #SUMMARY_MAX_JOBS_PER_RUN} jobs per run, and
+     * {@value #SUMMARY_MAX_WARNINGS} warning messages. SHA values are truncated to
+     * {@value #SUMMARY_SHA_PREFIX_LEN} characters.
+     *
+     * @return multi-line summary string; never {@code null}
+     */
+    public String summary() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("trace=").append(traceId == null ? "?" : traceId)
+                .append(" repo=").append(repoOwner == null ? "?" : repoOwner)
+                .append('/').append(repoName == null ? "?" : repoName);
+        int runCount = runs == null ? 0 : runs.size();
+        int jobCount = countJobs();
+        int warningCount = warnings == null ? 0 : warnings.size();
+        sb.append(" runs=").append(runCount)
+                .append(" jobs=").append(jobCount)
+                .append(" warnings=").append(warningCount);
+        appendWorkflowFiles(sb);
+
+        for (GiteaActions.ActionRunSummary run : selectRecentRuns()) {
+            sb.append('\n').append("  run:")
+                    .append(" id=").append(run.id())
+                    .append(" status=").append(nullSafe(run.status()))
+                    .append(" conclusion=").append(nullSafe(run.conclusion()))
+                    .append(" ref=").append(nullSafe(run.headBranch()))
+                    .append(" sha=").append(shortSha(run.headSha()))
+                    .append(" event=").append(nullSafe(run.event()))
+                    .append(" name=\"").append(safeName(run.name())).append('"');
+            appendJobs(sb, run.id());
+        }
+
+        appendWarnings(sb);
+        return sb.toString();
+    }
+
+    private int countJobs() {
+        if (jobsByRunId == null || jobsByRunId.isEmpty()) {
+            return 0;
+        }
+        int total = 0;
+        for (List<GiteaActions.ActionJobSummary> jobs : jobsByRunId.values()) {
+            if (jobs != null) {
+                total += jobs.size();
+            }
+        }
+        return total;
+    }
+
+    private void appendWorkflowFiles(StringBuilder sb) {
+        boolean haveGitea = giteaWorkflowFiles != null && !giteaWorkflowFiles.isEmpty();
+        boolean haveGithub = githubWorkflowFiles != null && !githubWorkflowFiles.isEmpty();
+        if (!haveGitea && !haveGithub) {
+            return;
+        }
+        sb.append(" workflow_files=[");
+        boolean first = true;
+        if (haveGitea) {
+            sb.append("gitea:");
+            sb.append(String.join(",", giteaWorkflowFiles));
+            first = false;
+        }
+        if (haveGithub) {
+            if (!first) {
+                sb.append(' ');
+            }
+            sb.append("github:");
+            sb.append(String.join(",", githubWorkflowFiles));
+        }
+        sb.append(']');
+    }
+
+    private List<GiteaActions.ActionRunSummary> selectRecentRuns() {
+        if (runs == null || runs.isEmpty()) {
+            return List.of();
+        }
+        List<GiteaActions.ActionRunSummary> ordered = new ArrayList<>(runs);
+        ordered.sort(Comparator.comparing(
+                GiteaActionsDiagnostics::runSortKey,
+                Comparator.nullsLast(Comparator.reverseOrder())));
+        if (ordered.size() <= SUMMARY_MAX_RUNS) {
+            return ordered;
+        }
+        return ordered.subList(0, SUMMARY_MAX_RUNS);
+    }
+
+    private static Instant runSortKey(GiteaActions.ActionRunSummary run) {
+        if (run.updatedAt() != null) {
+            return run.updatedAt();
+        }
+        return run.createdAt();
+    }
+
+    private void appendJobs(StringBuilder sb, long runId) {
+        if (jobsByRunId == null) {
+            return;
+        }
+        List<GiteaActions.ActionJobSummary> jobs = jobsByRunId.get(runId);
+        if (jobs == null || jobs.isEmpty()) {
+            return;
+        }
+        int limit = Math.min(jobs.size(), SUMMARY_MAX_JOBS_PER_RUN);
+        for (int i = 0; i < limit; i++) {
+            GiteaActions.ActionJobSummary job = jobs.get(i);
+            sb.append('\n').append("    job:")
+                    .append(" id=").append(job.id())
+                    .append(" status=").append(nullSafe(job.status()))
+                    .append(" conclusion=").append(nullSafe(job.conclusion()))
+                    .append(" runner=").append(nullSafe(job.runnerName()))
+                    .append(" name=\"").append(safeName(job.name())).append('"');
+        }
+        if (jobs.size() > limit) {
+            sb.append('\n').append("    ... (")
+                    .append(jobs.size() - limit)
+                    .append(" more jobs)");
+        }
+    }
+
+    private void appendWarnings(StringBuilder sb) {
+        if (warnings == null || warnings.isEmpty()) {
+            return;
+        }
+        int limit = Math.min(warnings.size(), SUMMARY_MAX_WARNINGS);
+        for (int i = 0; i < limit; i++) {
+            sb.append('\n').append("  warning: ")
+                    .append(safeName(Objects.toString(warnings.get(i), "")));
+        }
+        if (warnings.size() > limit) {
+            sb.append('\n').append("  ... (")
+                    .append(warnings.size() - limit)
+                    .append(" more warnings)");
+        }
+    }
+
+    private static String nullSafe(String value) {
+        return value == null ? "null" : value;
+    }
+
+    private static String shortSha(String sha) {
+        if (sha == null || sha.isEmpty()) {
+            return "null";
+        }
+        if (sha.length() <= SUMMARY_SHA_PREFIX_LEN) {
+            return sha;
+        }
+        return sha.substring(0, SUMMARY_SHA_PREFIX_LEN);
+    }
+
+    private static String safeName(String value) {
+        if (value == null) {
+            return "";
+        }
+        // Compact whitespace and trim to keep the summary one-entry-per-line. Length is
+        // bounded so a runaway run/job/warning name cannot blow up the message.
+        String collapsed = value.replace('\n', ' ').replace('\r', ' ').replace('"', '\'');
+        if (collapsed.length() > 200) {
+            return collapsed.substring(0, 200) + "...";
+        }
+        return collapsed;
+    }
 }

--- a/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
+++ b/src/main/java/dev/promptlm/testutils/gitea/GiteaContainer.java
@@ -485,7 +485,6 @@ public class GiteaContainer {
         }
 
         logGiteaActionsConfig();
-        logGiteaActionsDatabaseState();
 
         try {
             boolean registered = runnerRegistry.isRunnerRegistered(RUNNER_NAME);
@@ -545,52 +544,6 @@ public class GiteaContainer {
             }
         } catch (Exception e) {
             logger.warn("Failed to read Gitea actions config", e);
-        }
-    }
-
-    private void logGiteaActionsDatabaseState() {
-        try {
-            var sqliteCheck = container.execInContainer("sh", "-lc", "command -v sqlite3 >/dev/null 2>&1");
-            if (sqliteCheck.getExitCode() != 0) {
-                logger.warn("sqlite3 is not installed in the Gitea image; skipping Actions database diagnostics");
-                return;
-            }
-
-            var tables = container.execInContainer(
-                    "sqlite3",
-                    "/var/lib/gitea/data/gitea.db",
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'action_%' ORDER BY name;");
-            String tableList = tables.getStdout().trim();
-            if (!tableList.isBlank()) {
-                logger.warn("Gitea action tables: {}", tableList.replace("\n", ", "));
-            } else if (!tables.getStderr().isBlank()) {
-                logger.warn("Gitea action table discovery stderr: {}", tables.getStderr().trim());
-            } else {
-                logger.warn("No action_* tables found in Gitea database");
-            }
-
-            logGiteaActionsTableCount("action_run");
-            logGiteaActionsTableCount("action_task");
-            logGiteaActionsTableCount("action_runner");
-        } catch (Exception e) {
-            logger.warn("Failed to inspect Gitea actions database", e);
-        }
-    }
-
-    private void logGiteaActionsTableCount(String table) {
-        try {
-            var result = container.execInContainer(
-                    "sqlite3",
-                    "/var/lib/gitea/data/gitea.db",
-                    "SELECT COUNT(1) FROM " + table + ";");
-            String output = result.getStdout().trim();
-            if (!output.isBlank()) {
-                logger.warn("Gitea {} row count: {}", table, output);
-            } else if (!result.getStderr().isBlank()) {
-                logger.warn("Gitea {} count stderr: {}", table, result.getStderr().trim());
-            }
-        } catch (Exception e) {
-            logger.warn("Failed to count Gitea table {}", table, e);
         }
     }
 

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsSummaryTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsSummaryTest.java
@@ -1,0 +1,276 @@
+package dev.promptlm.testutils.gitea;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GiteaActionsDiagnostics#summary()}.
+ *
+ * <p>The summary string is folded into {@code GiteaWorkflowException}'s message on timeout
+ * (see {@link GiteaActions#waitForWorkflowRunBySha}), so it is a security surface: anything
+ * that leaks into the summary surfaces in any log line that captures the exception. These
+ * tests fix the format and — crucially — prove the redaction discipline: synthetic secret
+ * material placed in raw log fields must NOT appear in {@link GiteaActionsDiagnostics#summary()}.
+ */
+class GiteaActionsDiagnosticsSummaryTest {
+
+    @Test
+    void summarizesRunsAndJobs() {
+        GiteaActions.ActionRunSummary run = new GiteaActions.ActionRunSummary(
+                42L,
+                "Deploy",
+                "queued",
+                null,
+                "main",
+                "abcdef1234567890",
+                "push",
+                "http://gitea/run/42",
+                Instant.parse("2026-01-01T10:00:00Z"),
+                Instant.parse("2026-01-01T10:05:00Z"));
+        GiteaActions.ActionJobSummary job = new GiteaActions.ActionJobSummary(
+                7L,
+                "build",
+                "running",
+                null,
+                null,
+                null,
+                "runner-1");
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                "trace-001",
+                "owner",
+                "repo",
+                Instant.parse("2026-01-01T10:05:00Z"),
+                List.of("deploy.yml"),
+                List.of(),
+                List.of(run),
+                Map.of(42L, List.of(job)),
+                Map.of(),
+                Map.of(),
+                List.of(),
+                "runner log content",
+                "gitea log content",
+                List.of());
+
+        String summary = diagnostics.summary();
+
+        assertThat(summary)
+                .startsWith("trace=trace-001 repo=owner/repo runs=1 jobs=1 warnings=0")
+                .contains("workflow_files=[gitea:deploy.yml]")
+                .contains("run: id=42 status=queued conclusion=null ref=main sha=abcdef12 event=push name=\"Deploy\"")
+                .contains("job: id=7 status=running conclusion=null runner=runner-1 name=\"build\"");
+    }
+
+    @Test
+    void summaryNeverIncludesRawLogContent() {
+        // This is the redaction-discipline proof. We feed synthetic "secret" material into
+        // every raw log field that GiteaActionsDiagnostics carries — fields that exist
+        // precisely because the diagnostics collector tails runner / Gitea / job container
+        // logs, which can echo the runner registration token, HTTP Authorization headers,
+        // and caller-supplied workflow secrets. None of that material may leak into the
+        // summary string, because the summary is concatenated into the exception message and
+        // commonly logged via logger.error(e) by downstream test suites.
+        String secret = "GITEA_RUNNER_REGISTRATION_TOKEN=super-secret-token-DO-NOT-LOG";
+        byte[] jobLog = ("[step] echo SECRET=" + secret).getBytes();
+        GiteaActionsTaskContainerLog containerLog = new GiteaActionsTaskContainerLog(
+                "container-1",
+                List.of("/build"),
+                Instant.parse("2026-01-01T10:00:00Z"),
+                "STDOUT secret=" + secret);
+        GiteaActionsLogFile logFile = new GiteaActionsLogFile(
+                "/var/lib/gitea/actions_log/01.log",
+                42L,
+                "compressed-bytes contains " + secret);
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                "trace-redact",
+                "owner",
+                "repo",
+                Instant.parse("2026-01-01T10:00:00Z"),
+                List.of(),
+                List.of(),
+                List.of(),
+                Map.of(),
+                Map.of(99L, jobLog),
+                Map.of(99L, List.of(containerLog)),
+                List.of(logFile),
+                "runner stdout: " + secret + " --bootstrap",
+                "gitea logs: Authorization: token " + secret,
+                List.of("warning: see runner logs"));
+
+        String summary = diagnostics.summary();
+
+        assertThat(summary)
+                .as("summary must never carry raw log content that can contain secrets")
+                .doesNotContain("super-secret-token-DO-NOT-LOG")
+                .doesNotContain("Authorization: token")
+                .doesNotContain("GITEA_RUNNER_REGISTRATION_TOKEN");
+    }
+
+    @Test
+    void truncatesRunsAndJobsAtConfiguredCaps() {
+        Instant base = Instant.parse("2026-01-01T10:00:00Z");
+        java.util.List<GiteaActions.ActionRunSummary> manyRuns = new java.util.ArrayList<>();
+        java.util.Map<Long, List<GiteaActions.ActionJobSummary>> jobsByRunId = new java.util.HashMap<>();
+        for (int i = 1; i <= GiteaActionsDiagnostics.SUMMARY_MAX_RUNS + 3; i++) {
+            manyRuns.add(new GiteaActions.ActionRunSummary(
+                    i,
+                    "run-" + i,
+                    "queued",
+                    null,
+                    "main",
+                    "sha" + i,
+                    "push",
+                    null,
+                    base.plusSeconds(i),
+                    base.plusSeconds(i + 100)));
+        }
+        // Build many jobs for the most-recent run.
+        java.util.List<GiteaActions.ActionJobSummary> manyJobs = new java.util.ArrayList<>();
+        long mostRecentRunId = manyRuns.get(manyRuns.size() - 1).id();
+        for (int j = 1; j <= GiteaActionsDiagnostics.SUMMARY_MAX_JOBS_PER_RUN + 2; j++) {
+            manyJobs.add(new GiteaActions.ActionJobSummary(
+                    j,
+                    "job-" + j,
+                    "running",
+                    null,
+                    null,
+                    null,
+                    "runner-1"));
+        }
+        jobsByRunId.put(mostRecentRunId, manyJobs);
+
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                "trace-cap",
+                "owner",
+                "repo",
+                base,
+                List.of(),
+                List.of(),
+                manyRuns,
+                jobsByRunId,
+                Map.of(),
+                Map.of(),
+                List.of(),
+                "",
+                "",
+                List.of("w1", "w2", "w3", "w4", "w5"));
+
+        String summary = diagnostics.summary();
+
+        long runLines = summary.lines().filter(line -> line.contains("run: id=")).count();
+        long jobLines = summary.lines().filter(line -> line.contains("job: id=")).count();
+        long warningLines = summary.lines().filter(line -> line.contains("warning:")).count();
+
+        assertThat(runLines).isEqualTo(GiteaActionsDiagnostics.SUMMARY_MAX_RUNS);
+        assertThat(jobLines).isEqualTo(GiteaActionsDiagnostics.SUMMARY_MAX_JOBS_PER_RUN);
+        assertThat(warningLines).isEqualTo(GiteaActionsDiagnostics.SUMMARY_MAX_WARNINGS);
+        assertThat(summary)
+                .contains("more jobs)")
+                .contains("more warnings)");
+    }
+
+    @Test
+    void summarizesEmptyDiagnostics() {
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        String summary = diagnostics.summary();
+
+        assertThat(summary).isEqualTo("trace=? repo=?/? runs=0 jobs=0 warnings=0");
+    }
+
+    @Test
+    void truncatesLongNames() {
+        String longName = "x".repeat(500);
+        GiteaActions.ActionRunSummary run = new GiteaActions.ActionRunSummary(
+                1L,
+                longName,
+                "queued",
+                null,
+                "main",
+                "abc",
+                "push",
+                null,
+                Instant.parse("2026-01-01T10:00:00Z"),
+                Instant.parse("2026-01-01T10:00:00Z"));
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                "trace-long",
+                "owner",
+                "repo",
+                Instant.parse("2026-01-01T10:00:00Z"),
+                List.of(),
+                List.of(),
+                List.of(run),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                List.of(),
+                null,
+                null,
+                List.of());
+
+        String summary = diagnostics.summary();
+
+        assertThat(summary)
+                .contains("...")
+                .doesNotContain("x".repeat(300));
+    }
+
+    @Test
+    void escapesQuotesAndNewlinesInNames() {
+        GiteaActions.ActionRunSummary run = new GiteaActions.ActionRunSummary(
+                1L,
+                "name with \"quotes\" and\nnewlines",
+                "queued",
+                null,
+                "main",
+                "abc",
+                "push",
+                null,
+                Instant.parse("2026-01-01T10:00:00Z"),
+                Instant.parse("2026-01-01T10:00:00Z"));
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                "trace-esc",
+                "owner",
+                "repo",
+                Instant.parse("2026-01-01T10:00:00Z"),
+                List.of(),
+                List.of(),
+                List.of(run),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                List.of(),
+                null,
+                null,
+                List.of());
+
+        String summary = diagnostics.summary();
+
+        // The summary is line-oriented (one run/job/warning per line). Embedded newlines
+        // would break the format; embedded double-quotes would confuse readers looking for
+        // the closing quote of the name field.
+        assertThat(summary)
+                .doesNotContain("\nnewlines")
+                .doesNotContain("\"quotes\"");
+        long runLineCount = summary.lines().filter(line -> line.contains("run: id=")).count();
+        assertThat(runLineCount).isEqualTo(1);
+    }
+}

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsSummaryTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsDiagnosticsSummaryTest.java
@@ -197,6 +197,44 @@ class GiteaActionsDiagnosticsSummaryTest {
     }
 
     @Test
+    void preservesShaWhenExactlyAtTheBoundaryLength() {
+        // Boundary case for shortSha(): a SHA of exactly SUMMARY_SHA_PREFIX_LEN characters
+        // must be returned in full (not truncated and not padded). One shorter and one longer
+        // are already exercised by other tests; this pins the equality branch.
+        String boundary = "a".repeat(GiteaActionsDiagnostics.SUMMARY_SHA_PREFIX_LEN);
+        GiteaActions.ActionRunSummary run = new GiteaActions.ActionRunSummary(
+                1L,
+                "build",
+                "queued",
+                null,
+                "main",
+                boundary,
+                "push",
+                null,
+                Instant.parse("2026-01-01T10:00:00Z"),
+                Instant.parse("2026-01-01T10:00:00Z"));
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                "trace-boundary",
+                "owner",
+                "repo",
+                Instant.parse("2026-01-01T10:00:00Z"),
+                List.of(),
+                List.of(),
+                List.of(run),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                List.of(),
+                null,
+                null,
+                List.of());
+
+        String summary = diagnostics.summary();
+
+        assertThat(summary).contains("sha=" + boundary + " ");
+    }
+
+    @Test
     void truncatesLongNames() {
         String longName = "x".repeat(500);
         GiteaActions.ActionRunSummary run = new GiteaActions.ActionRunSummary(

--- a/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsTest.java
+++ b/src/test/java/dev/promptlm/testutils/gitea/GiteaActionsTest.java
@@ -11,6 +11,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -77,6 +78,68 @@ class GiteaActionsTest {
                 Duration.ofMillis(50)))
                 .isInstanceOf(GiteaWorkflowException.class)
                 .hasMessageContaining("Timed out waiting for workflow run");
+    }
+
+    @Test
+    void timeoutMessageIncludesDiagnosticsSummaryAndExposesFullDiagnostics() {
+        // Verifies the AC-1/AC-2 contract: when a diagnostics collector is wired and a wait
+        // times out, the exception's getMessage() includes the redacted summary AND the
+        // structured diagnostics payload remains available via getDiagnostics().
+        GiteaActions actions = buildActionsClientWithRuns("{\"workflow_runs\": []}");
+        GiteaActions.ActionRunSummary run = new GiteaActions.ActionRunSummary(
+                42L,
+                "Deploy",
+                "queued",
+                null,
+                "main",
+                "abcdef1234567890",
+                "push",
+                "http://gitea/run/42",
+                Instant.parse("2026-01-01T10:00:00Z"),
+                Instant.parse("2026-01-01T10:05:00Z"));
+        GiteaActionsDiagnostics diagnostics = new GiteaActionsDiagnostics(
+                "trace-abc",
+                "owner",
+                "repo",
+                Instant.parse("2026-01-01T10:05:00Z"),
+                List.of("deploy.yml"),
+                List.of(),
+                List.of(run),
+                Map.of(42L, List.of()),
+                Map.of(),
+                Map.of(),
+                List.of(),
+                "runner stdout: GITEA_RUNNER_REGISTRATION_TOKEN=must-not-leak",
+                "gitea logs: Authorization: token must-not-leak",
+                List.of());
+        GiteaActionsDiagnosticsCollector collector = mock(GiteaActionsDiagnosticsCollector.class);
+        when(collector.collect(any(), any(), any())).thenReturn(diagnostics);
+        actions.setDiagnosticsCollector(collector);
+
+        try {
+            actions.waitForWorkflowRunBySha(
+                    "owner",
+                    "repo",
+                    "abcd",
+                    Duration.ofMillis(200),
+                    Duration.ofMillis(50));
+        } catch (GiteaWorkflowException e) {
+            // AC-1: enriched message includes the summary.
+            assertThat(e.getMessage())
+                    .startsWith("Timed out waiting for workflow run") // preserve original prefix
+                    .contains("trace=trace-abc")
+                    .contains("run: id=42")
+                    .contains("status=queued")
+                    .contains("sha=abcdef12");
+            // Redaction discipline: the raw log fields must NOT leak into the message.
+            assertThat(e.getMessage())
+                    .as("raw runner/gitea log bodies must not leak through summary")
+                    .doesNotContain("must-not-leak");
+            // AC-2: structured payload remains available via getDiagnostics().
+            assertThat(e.getDiagnostics()).isSameAs(diagnostics);
+            return;
+        }
+        throw new AssertionError("expected GiteaWorkflowException");
     }
 
     @Test


### PR DESCRIPTION
Closes #50.

## Summary

Two distinct improvements for downstream test suites:

- **Part A — observability.** `GiteaActions.waitForWorkflowRunBySha(...)` now folds a redacted, line-oriented diagnostics summary into the `GiteaWorkflowException` message on timeout. Callers that only log `e.getMessage()` get actionable run/job state without having to drill into `getDiagnostics()`. The leading substring `"Timed out waiting for workflow run"` is preserved; the structured `getDiagnostics()` payload is unchanged.
- **Part B — cleanup.** Removed the broken `sqlite3` CLI diagnostics in `GiteaContainer`. The default Gitea image doesn't ship `sqlite3`, so the probes always failed with "command not found" and produced contradictory warn-level startup logs next to other diagnostics that already claimed the SQLite backend was working. The `GITEA__database__DB_TYPE=sqlite3` env var is preserved (carved out per the maintainer comment on #50).

## Example: before vs. after

Before — `e.getMessage()` on timeout:

```
Timed out waiting for workflow run for testuser/test-repo sha=abc1234deadbeef
```

After:

```
Timed out waiting for workflow run for testuser/test-repo sha=abc1234deadbeef
trace=trace-001 repo=testuser/test-repo runs=2 jobs=2 warnings=1 workflow_files=[gitea:deploy.yml]
  run: id=2 status=queued conclusion=null ref=main sha=abc12345 event=push name="deploy"
    job: id=7 status=running conclusion=null runner=runner-1 name="build"
  run: id=1 status=cancelled conclusion=cancelled ref=main sha=abc12345 event=push name="deploy"
  warning: job log endpoint returned 404 — fell back to task container logs
```

## Security note (whitelist redaction)

`GiteaActionsDiagnostics.summary()` is an explicit field whitelist. It surfaces `traceId`, repo identity, workflow file names, per-run (id / status / conclusion / ref / sha-prefix / event / name) and per-job (id / status / conclusion / runner / name), and a count of warnings (plus first 3 messages). It **never** surfaces `jobLogsByJobId`, `runnerLogs`, `giteaLogs`, `taskContainerLogsByJobId`, or `giteaActionsLogFiles` contents — those raw-log fields can carry the runner registration token, caller-supplied workflow secrets, or HTTP `Authorization: token …` echoes. A dedicated unit test (`GiteaActionsDiagnosticsSummaryTest.summaryNeverIncludesRawLogContent`) seeds synthetic `"GITEA_RUNNER_REGISTRATION_TOKEN=super-secret-token-DO-NOT-LOG"` into every raw-log field and asserts the summary does not carry it.

Output is bounded: at most 5 most-recent runs, 5 jobs per run, 3 warnings; SHAs truncated to 8 chars; run/job/warning names whitespace-collapsed and capped at 200 chars.

## Verification

Run: `JAVA_HOME=<jdk-17+> ./mvnw -B test`.

- **All unit tests green** — including 7 new tests in `GiteaActionsDiagnosticsSummaryTest` (happy path, redaction proof, caps, empty diagnostics, SHA boundary, name truncation, quote/newline escaping) and 1 new test in `GiteaActionsTest` (`timeoutMessageIncludesDiagnosticsSummaryAndExposesFullDiagnostics`, end-to-end through the real catch block).
- **All Gitea-only integration tests green** — notably `GithubWorkflowsContainerJobsIntegrationTest` (real Gitea container + Actions runner + workflow dispatch through the changed `waitForWorkflowRunBySha` API).
- **`CiWorkflowHarnessTest` and `GiteaWithArtifactoryAnnotationIntegrationTest` failed environmentally** in `ArtifactoryTestExtension.beforeAll` waiting for the JFrog `artifactory-oss:7.77.5` HTTP `/api/system/ping`. Test bodies never executed. Failure surface is the Artifactory container cold-start; not on any code path this PR modifies. The `snapshot.yml` workflow on merge will re-run these against a fresher environment.

Static-grep evidence:

- AC-3 (no sqlite3 CLI calls remain): `grep -rn 'execInContainer.*sqlite3\|command -v sqlite3\|"sqlite3"' src/main/java/` → only the env-var line at `GiteaContainer.java:137`.
- AC-4 (no `sqlite=true` log claims): `grep -rn 'sqlite=true\|sqlite available\|sqlite is installed' src/main/java/` → 0 hits.
- AC-5 (runner registration unchanged): `git diff origin/main..HEAD -- '*RunnerRegistry*' '*Runner*'` → empty.

## Commits

1. `chore(repo): gitignore .claude/ agent state` — repo hygiene (Claude Code agent state is local-only by default per the deliver-issue procedure).
2. `fix(diagnostics): remove broken sqlite3 CLI probes from GiteaContainer` — closes Part B.
3. `feat(observability): surface diagnostics summary in workflow-timeout exception` — closes Part A.
4. `test: cover SHA boundary case in GiteaActionsDiagnostics.summary()` — independent review follow-up.

## Test plan

- [ ] CI green on this PR (Surefire unit suite).
- [ ] `snapshot.yml` workflow re-runs the integration suite against a fresher Artifactory environment after merge.
- [ ] Reviewer spot-checks `GiteaActionsDiagnostics.summary()` for the whitelist discipline.
- [ ] Reviewer reviews the redaction unit test (`summaryNeverIncludesRawLogContent`) for sufficiency.

## Follow-up

A pre-existing token-echo logging concern at `GiteaContainer.java:348/355` was identified during the security survey for this PR but is out of scope here. To be tracked in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)