### PR TITLE
ci: expand dependabot, add license-eye config + oss-checks caller

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates — promptlm-junit-gitea-artifactory
+# Org template: https://github.com/promptLM/.github/blob/main/dependabot.template.yml
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/oss-checks.yml
+++ b/.github/workflows/oss-checks.yml
@@ -1,0 +1,28 @@
+name: oss-checks
+
+# Thin caller of the org-wide reusable workflow at
+# promptLM/.github/.github/workflows/oss-checks.yml.
+#
+# License-header check is OFF for now: 47 of 48 .java files in this repo
+# pre-date the org-wide Apache-2.0 header policy and would fail license-eye
+# immediately. Run `license-eye -c .licenserc.yaml header fix` once locally,
+# commit the result, then flip `check-license-headers: true` here.
+#
+# Gitleaks runs without a per-repo .gitleaks.toml (the reusable warns and
+# falls back to default rules). Add a .gitleaks.toml at the repo root to
+# tune the allowlist if CI noise emerges.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    uses: promptLM/.github/.github/workflows/oss-checks.yml@main
+    with:
+      check-license-headers: false

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,27 @@
+header:
+  license:
+    content: |
+      Copyright 2025 promptLM
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+  paths:
+    - "**/*.java"
+    - "**/*.sh"
+
+  paths-ignore:
+    - "**/target/**"
+    - ".git/**"
+    - ".idea/**"
+    - ".agents/**"
+    - ".claude/**"


### PR DESCRIPTION
## Summary

- **\`.github/dependabot.yml\`** — add \`github-actions\` ecosystem (was maven-only).
- **\`.licenserc.yaml\`** (new) — Apache-2.0 header config matching the org-wide license-eye pattern. Patterns cover \`.java\` and \`.sh\`.
- **\`.github/workflows/oss-checks.yml\`** (new) — thin caller of \`promptLM/.github/.github/workflows/oss-checks.yml@main\`. License-header check is OFF for now because 47 of 48 \`.java\` files pre-date the org-wide Apache-2.0 header policy. Once \`license-eye -c .licenserc.yaml header fix\` is run and committed, flip \`check-license-headers: true\` here.

Depends on the org-github reusable workflow PR; merge that one first.

## Test plan

- [ ] After this merges, next PR triggers oss-checks workflow which now \`uses:\` the org reusable. Expect green gitleaks run (default rules — no \`.gitleaks.toml\` in this repo yet; warning is informational).
- [ ] Follow-up PR: run \`license-eye header fix\`, then enable the license-header check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)