### PR TITLE
build(deps): bump jackson-annotations to 2.22 and jackson-databind to 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
         <testcontainers.version>2.0.5</testcontainers.version>
         <awaitility.version>4.3.0</awaitility.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <jackson.annotations.version>2.21</jackson.annotations.version>
+        <jackson.annotations.version>2.22</jackson.annotations.version>
         <jackson.core.version>2.21.4</jackson.core.version>
-        <jackson.databind.version>2.21.3</jackson.databind.version>
+        <jackson.databind.version>2.22.0</jackson.databind.version>
         <mockito.version>5.23.0</mockito.version>
         <bytebuddy.version>1.18.8</bytebuddy.version>
         <zstd.version>1.5.7-9</zstd.version>


### PR DESCRIPTION
## Summary
- Bumps `jackson-annotations` from 2.21 → 2.22
- Bumps `jackson-databind` from 2.21.3 → 2.22.0

Consolidates dependabot PRs #66 and #67, which both conflicted after #65 (jackson-core 2.21.4) merged. Single PR keeps the Jackson family aligned at 2.22.

Closes #66
Closes #67

## Test plan
- [x] CI build passes