### PR TITLE
test(docker): add DockerAvailableExtensionTest; document skip in READ…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@
 # OS/files
 .DS_Store
 *.log
+
+# Claude Code agent state and scratch artifacts.
+# Issue-delivery artefacts (.claude/issue-delivery/) are local-only by default
+# per .claude/commands/github-issue-delivery/PROCEDURE.md — the PR description
+# is the durable record. Repos that want the audit trail committed should
+# remove or scope this rule.
+/.claude/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# gitleaks configuration for promptlm-junit-gitea-artifactory.
+#
+# The org-wide oss-checks workflow (promptLM/.github) runs gitleaks against
+# every PR + push to main. Without this file the scan runs with default rules
+# only and warns. With it, we extend the default rule set and pin
+# repo-specific allowlist entries here as CI noise emerges.
+#
+# Reference: https://github.com/gitleaks/gitleaks#configuration
+
+[extend]
+useDefault = true
+
+# Project-specific allowlist entries go below. Keep narrow — prefer matching
+# a specific file/path or regex rather than disabling whole rule IDs.
+#
+# Example shape (kept commented until needed):
+#
+# [[allowlist]]
+# description = "Test fixtures with synthetic tokens"
+# paths = ['''src/test/resources/.*\.json''']
+# regexes = ['''ghp_[A-Za-z0-9]{36}''']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. The format
+loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Unreleased
+
+### Added
+
+- **Fail-fast Docker availability precondition for `@WithGitea` and
+  `@WithArtifactory`** (#58, baseline shipped in #59). A new
+  `DockerAvailableExtension` is auto-wired into both annotations via
+  `@ExtendWith` and pings the Docker daemon with a 5-second hard cap before any
+  container is started. If Docker is unreachable, the test class is skipped
+  (not failed) via JUnit's `Assumptions` with an actionable remediation message
+  pointing at the typical macOS broken-symlink fix
+  (`sudo ln -sf "$HOME/.docker/run/docker.sock" /var/run/docker.sock`).
+  Consumers of `@WithGitea` / `@WithArtifactory` inherit this behaviour
+  automatically — no extra `@ExtendWith` registration required.
+- `DockerAvailableExtensionTest` covering the skip-with-remediation path on a
+  connection-refused ping, the timeout-cap branch, and the no-op behaviour on a
+  healthy host.
+
+### Changed
+
+- `DockerAvailableExtension` gains a package-private constructor that accepts a
+  `Runnable` ping action and a timeout (in seconds). This is a unit-test seam;
+  the public no-arg constructor (the one JUnit uses via `@ExtendWith`) is
+  unchanged, so downstream behaviour and wiring are preserved.
+
+### Notes
+
+- README "Setup" section now describes the skip behaviour and the remediation
+  hint so developers running into the macOS broken-`/var/run/docker.sock`
+  symlink case find the fix without reading source.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ PromptLM Gitea + Artifactory Test Support is a JUnit 5 library that provisions G
 - Java 17+
 - Docker (required by Testcontainers)
 
+### When Docker is unreachable
+
+Tests annotated with `@WithGitea` or `@WithArtifactory` are guarded by a
+fail-fast Docker-availability precondition. If the Docker daemon does not
+respond within 5 seconds, the test class is **skipped** (not failed) with an
+actionable remediation hint — no more 4-minute Testcontainers timeouts with
+confusing stack traces. The most common cause on macOS is a broken
+`/var/run/docker.sock` symlink after a Docker Desktop reinstall, fixed with:
+
+```sh
+sudo ln -sf "$HOME/.docker/run/docker.sock" /var/run/docker.sock
+```
+
+The precondition is wired automatically — consumers do not need to add
+`@ExtendWith(DockerAvailableExtension.class)` to their own test classes.
+
 ## Dependency
 
 ```xml

--- a/src/main/java/dev/promptlm/testutils/docker/DockerAvailableExtension.java
+++ b/src/main/java/dev/promptlm/testutils/docker/DockerAvailableExtension.java
@@ -47,7 +47,7 @@ public final class DockerAvailableExtension implements BeforeAllCallback {
 
     private static final Logger log = LoggerFactory.getLogger(DockerAvailableExtension.class);
 
-    private static final long PING_TIMEOUT_SECONDS = 5;
+    static final long DEFAULT_PING_TIMEOUT_SECONDS = 5;
 
     private static final String REMEDIATION_HINT = """
             Docker is not reachable from this JVM. Tests using @WithGitea / @WithArtifactory \
@@ -63,18 +63,37 @@ public final class DockerAvailableExtension implements BeforeAllCallback {
             Then re-run the test.
             Cause: %s""";
 
+    private final Runnable pingAction;
+    private final long pingTimeoutSeconds;
+
+    /** Production constructor used by JUnit when wired via {@code @ExtendWith}. */
+    public DockerAvailableExtension() {
+        this(() -> DockerClientFactory.instance().client().pingCmd().exec(),
+                DEFAULT_PING_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * Test seam — lets unit tests inject a failing or sleeping ping action and a short timeout
+     * so the skip path can be exercised without a real Docker daemon and without cross-thread
+     * static mocking. Package-private on purpose; consumers should use the no-arg constructor
+     * via {@code @ExtendWith}.
+     */
+    DockerAvailableExtension(Runnable pingAction, long pingTimeoutSeconds) {
+        this.pingAction = pingAction;
+        this.pingTimeoutSeconds = pingTimeoutSeconds;
+    }
+
     @Override
     public void beforeAll(ExtensionContext context) {
-        CompletableFuture<Void> ping = CompletableFuture.runAsync(() ->
-                DockerClientFactory.instance().client().pingCmd().exec());
+        CompletableFuture<Void> ping = CompletableFuture.runAsync(pingAction);
         try {
-            ping.get(PING_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            ping.get(pingTimeoutSeconds, TimeUnit.SECONDS);
             log.debug("Docker daemon reachable; proceeding with Testcontainers-backed test {}",
                     context.getDisplayName());
         }
         catch (TimeoutException ex) {
             ping.cancel(true);
-            skip("ping timed out after " + PING_TIMEOUT_SECONDS + "s");
+            skip("ping timed out after " + pingTimeoutSeconds + "s");
         }
         catch (ExecutionException ex) {
             Throwable cause = ex.getCause() != null ? ex.getCause() : ex;

--- a/src/test/java/dev/promptlm/testutils/docker/DockerAvailableExtensionTest.java
+++ b/src/test/java/dev/promptlm/testutils/docker/DockerAvailableExtensionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 promptLM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.promptlm.testutils.docker;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opentest4j.TestAbortedException;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DockerAvailableExtension}.
+ *
+ * <p>These exercise the precondition's failure paths without a real Docker daemon by injecting
+ * a {@link Runnable} ping action into the package-private constructor. The skip-with-remediation
+ * behaviour is what consumers of {@code @WithGitea} / {@code @WithArtifactory} see on a developer
+ * machine where Docker is unreachable (the canonical case being macOS Docker Desktop with a
+ * broken {@code /var/run/docker.sock} symlink, equivalent in effect to {@code DOCKER_HOST=tcp://localhost:1}).
+ */
+class DockerAvailableExtensionTest {
+
+    @Test
+    void skipsWithRemediationHintWhenDockerPingFails() {
+        // Equivalent to DOCKER_HOST=tcp://localhost:1 — the docker-java client surfaces an
+        // unreachable daemon as a runtime exception inside the ping invocation.
+        Runnable connectionRefused = () -> {
+            throw new RuntimeException("Connection refused");
+        };
+        DockerAvailableExtension extension =
+                new DockerAvailableExtension(connectionRefused, 5);
+        ExtensionContext context = newExtensionContext();
+
+        assertThatThrownBy(() -> extension.beforeAll(context))
+                .isInstanceOf(TestAbortedException.class)
+                .hasMessageContaining("Docker is not reachable from this JVM")
+                .hasMessageContaining("Tests using @WithGitea / @WithArtifactory")
+                .hasMessageContaining("docker info")
+                .hasMessageContaining("Cannot connect to the Docker daemon at unix:///var/run/docker.sock")
+                .hasMessageContaining("sudo ln -sf \"$HOME/.docker/run/docker.sock\" /var/run/docker.sock")
+                .hasMessageContaining("Cause: RuntimeException: Connection refused");
+    }
+
+    @Test
+    void skipsWithTimeoutCauseWhenPingExceedsHardCap() {
+        // Sleep longer than the (small, test-only) timeout so the CompletableFuture.get(..)
+        // call surfaces a TimeoutException and the extension routes through the timeout branch.
+        Runnable slowPing = () -> {
+            try {
+                TimeUnit.SECONDS.sleep(2);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        DockerAvailableExtension extension =
+                new DockerAvailableExtension(slowPing, 1);
+        ExtensionContext context = newExtensionContext();
+
+        long startNanos = System.nanoTime();
+        assertThatThrownBy(() -> extension.beforeAll(context))
+                .isInstanceOf(TestAbortedException.class)
+                .hasMessageContaining("Docker is not reachable from this JVM")
+                .hasMessageContaining("sudo ln -sf \"$HOME/.docker/run/docker.sock\" /var/run/docker.sock")
+                .hasMessageContaining("Cause: ping timed out after 1s");
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        // Hard cap is the timeout itself plus a small margin for CompletableFuture scheduling.
+        // We do NOT want the slow-ping to run to completion (2s) — that would mean the cancel
+        // didn't take effect and the timeout branch was bypassed.
+        assertThat(elapsedMs)
+                .as("timeout branch should fire within ~ timeoutSeconds, not wait for the ping to finish")
+                .isLessThan(1_900);
+    }
+
+    @Test
+    void healthyPingReturnsWithoutThrowing() {
+        // No-op runnable simulates a successful, fast Docker ping. The extension should proceed
+        // silently — no TestAbortedException, no measurable overhead beyond CompletableFuture
+        // scheduling.
+        DockerAvailableExtension extension =
+                new DockerAvailableExtension(() -> {
+                }, 5);
+        ExtensionContext context = newExtensionContext();
+
+        long startNanos = System.nanoTime();
+        extension.beforeAll(context);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+        // <50 ms healthy-host overhead is the AC-2 claim. Allow a generous margin for CI noise;
+        // the point is to detect catastrophic regression (e.g. someone making the success path
+        // synchronously block for seconds), not to micro-benchmark.
+        assertThat(elapsedMs)
+                .as("healthy-host overhead must remain trivially small")
+                .isLessThan(500);
+    }
+
+    private static ExtensionContext newExtensionContext() {
+        ExtensionContext context = mock(ExtensionContext.class);
+        when(context.getDisplayName()).thenReturn("DockerAvailableExtensionTest");
+        return context;
+    }
+}


### PR DESCRIPTION
…ME + CHANGELOG

Closes the remaining acceptance criteria on issue #58 left open after PR #59 (which shipped the DockerAvailableExtension itself and its @ExtendWith wiring into @WithGitea / @WithArtifactory):

- AC-4: new DockerAvailableExtensionTest covers the skip path on a connection-refused ping (the same effect DOCKER_HOST=tcp://localhost:1 produces inside docker-java), the timeout-cap branch, and the no-op healthy-host path. Runs in ~2 s with no real Docker daemon.
- AC-5: README "Setup" gains a "When Docker is unreachable" subsection that documents the auto-skip, the 5 s ping, and the canonical `sudo ln -sf "$HOME/.docker/run/docker.sock" /var/run/docker.sock` remediation for the macOS broken-symlink case.
- AC-6: first-ever CHANGELOG entry (Keep-a-Changelog style) under ## Unreleased, crediting #58 / #59 and noting the test-seam refactor.

To enable AC-4 without relying on cross-thread static mocking of DockerClientFactory, DockerAvailableExtension gains a package-private constructor that accepts a Runnable ping action and a timeout. The public no-arg constructor (the one JUnit uses via @ExtendWith) is unchanged in behavior — it supplies the original
`() -> DockerClientFactory.instance().client().pingCmd().exec()` and the 5-second default. PING_TIMEOUT_SECONDS is renamed to DEFAULT_PING_TIMEOUT_SECONDS and widened from private to package-private to support the test seam; no public API surface changes.

Adds `/.claude/` to .gitignore so issue-delivery scratch state stays local (same rule as #50's PR, harmless if both land).