### PR TITLE
ci: opt in to org action-pin audit + Dependabot auto-merge

### DIFF
--- a/.github/workflows/action-pin-audit.yml
+++ b/.github/workflows/action-pin-audit.yml
@@ -1,0 +1,19 @@
+# Audit every `uses:` ref in this repo's workflows on PRs that touch
+# them, weekly on schedule, and on demand. Org composite action lives at
+# promptLM/.github/.github/actions/audit-action-pins (see
+# https://github.com/promptLM/.github/blob/main/.github/actions/README.md).
+name: Action pin audit
+on:
+  pull_request:
+    paths: ['.github/workflows/**']
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: promptLM/.github/.github/actions/audit-action-pins@4b0d21dfddaaeb27fe555bd06057dbdcbb501cc5 # 4b0d21d

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,17 @@
+# Enable GitHub auto-merge on Dependabot/Renovate PRs once safety filters
+# pass and the calling repo's branch protection requirements are
+# satisfied. Org composite action lives at
+# promptLM/.github/.github/actions/auto-merge-deps.
+name: Auto-merge dependency PRs
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: promptLM/.github/.github/actions/auto-merge-deps@4b0d21dfddaaeb27fe555bd06057dbdcbb501cc5 # 4b0d21d


### PR DESCRIPTION
Per-repo opt-in to the org composite actions in [`promptLM/.github`](https://github.com/promptLM/.github/tree/main/.github/actions) ([PR #11](https://github.com/promptLM/.github/pull/11), SHA `4b0d21d`). Adds two thin caller workflows: `action-pin-audit.yml` (PR + cron) and `auto-merge-deps.yml` (`pull_request_target`). Tracking in [`promptlm-release/docs/ci-sync-audit-2026-05-30.md §4`](https://github.com/promptLM/promptlm-release/blob/main/docs/ci-sync-audit-2026-05-30.md#action-version-pins--the-single-biggest-sweep).