### PR TITLE
fix(ci): correct release-please-action SHA pin (v4.1.3 -> v4.1.5)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
       tag_name:        ${{ steps.release.outputs.tag_name }}
       version:         ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.1.3
+      - uses: googleapis/release-please-action@5792afc6b46e9bb55deda9eda973a18c226bc3fc # v4.1.5
         id: release
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

- The pin `a02a34c4d625f9be7cb89156071d8567266a2445` introduced in #77 does not resolve, causing the release-please workflow to fail with `startup_failure` (run [26845334583](https://github.com/promptLM/promptlm-junit-gitea-artifactory/actions/runs/26845334583)) and no `chore(main): release 1.3.0` PR was opened.
- Replace with the real SHA `5792afc6b46e9bb55deda9eda973a18c226bc3fc` for **v4.1.5** (latest v4 release at time of fix; Dependabot would bump v4.1.3 → v4.1.5 anyway).

## Test plan

- [ ] On merge, `release-please.yml` runs on the `main` push and completes successfully.
- [ ] A PR titled `chore(main): release 1.3.0` is opened by the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)