### PR TITLE
ci: isolate release-please startup_failure by disabling publish job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,12 +35,15 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    uses: promptLM/.github/.github/workflows/release-java-central.yml@main
-    with:
-      version: ${{ needs.release-please.outputs.tag_name }}
-      java-version: '21'
-      environment: maven-central-publish
-    secrets: inherit
+  # publish:
+  #   needs: release-please
+  #   if: needs.release-please.outputs.release_created == 'true'
+  #   uses: promptLM/.github/.github/workflows/release-java-central.yml@main
+  #   with:
+  #     version: ${{ needs.release-please.outputs.tag_name }}
+  #     java-version: '21'
+  #     environment: maven-central-publish
+  #   secrets: inherit
+  #
+  # Temporarily disabled to isolate a startup_failure cause. Will be re-enabled
+  # once the cause is understood.


### PR DESCRIPTION
## Why

`release-please.yml` has failed at startup (zero jobs created) on two consecutive pushes to main (runs [26845334583](https://github.com/promptLM/promptlm-junit-gitea-artifactory/actions/runs/26845334583), [26846212723](https://github.com/promptLM/promptlm-junit-gitea-artifactory/actions/runs/26846212723)). GitHub's API exposes no error detail for `startup_failure` runs — `gh run view --log-failed` returns 404 because no jobs were created.

The reusable workflow ref resolves correctly (visible in `referenced_workflows[]`), so the issue is in job-graph validation, not reference resolution.

## What this PR does

Comment out the `publish:` job so only the `release-please:` job remains. If startup succeeds and the rolling release PR appears, the cause is in the reusable-workflow call (inputs, secrets, environment, or something inside the reusable's own job graph). If startup still fails, the cause is in the `release-please:` job or workflow preamble.

Either way we get a faster signal than reasoning from YAML.

## Followups

- If startup succeeds: re-enable `publish:` in a separate PR, root-cause the reusable wiring, fix.
- If startup still fails: continue diagnosis with a minimal reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)