### PR TITLE
fix(ci): set skip-snapshot=true on release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
   "packages": {
     ".": {
       "package-name": "promptlm-junit-gitea-artifactory",
+      "skip-snapshot": true,
       "changelog-sections": [
         { "type": "feat",     "section": "Added" },
         { "type": "fix",      "section": "Fixed" },


### PR DESCRIPTION
## Summary

Add \`\"skip-snapshot\": true\` to the \`.\` package block in [release-please-config.json](release-please-config.json).

## Why

release-please's Java/Maven strategy ([src/strategies/java.ts:83-92](https://github.com/googleapis/release-please/blob/main/src/strategies/java.ts#L83-L92)) always checks \`needsSnapshot()\` before opening a release PR. On the first run after adopting the action against an existing repo whose \`pom.xml\` is already at a \`-SNAPSHOT\` version, it opens a "snapshot stabilization" PR titled \`chore(main): release 1.2.1-SNAPSHOT\` with an empty diff (PR #80, now closed). Only on the *next* run does it open the real release PR.

\`skip-snapshot\` ([src/manifest.ts:193](https://github.com/googleapis/release-please/blob/main/src/manifest.ts#L193)) is the documented per-package option that disables this stage. With it set, release-please goes straight to opening the release PR.

## Expected behaviour on merge

The next \`main\` push triggers \`release-please\`, which opens a PR titled \`chore(main): release 1.3.0\` (minor bump driven by the two \`feat:\` commits) with:

- \`pom.xml\`: \`1.2.1-SNAPSHOT\` → \`1.3.0\`
- \`CHANGELOG.md\`: new \`## [1.3.0]\` section with Added / Fixed / Dependencies / CI / Tests / Documentation breakdown
- \`.release-please-manifest.json\`: \`1.2.0\` → \`1.3.0\`

That's the diff we've been chasing.

## Followups

- Snapshot suffix management for \`pom.xml\` after a release (\`1.3.0\` → \`1.3.1-SNAPSHOT\`) goes in the follow-up that removes the old \`prepare-release.yml\` / \`tag-release.yml\` / \`release.yml\` workflows. For now the existing flow still handles it.
- Re-enable the \`publish:\` job (currently commented out from #79's debug isolation) once the release PR for 1.3.0 has been validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)