### PR TITLE
fix(ci): grant id-token + attestations perms to unblock reusable publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Granted at the caller level so the org reusable workflow's deploy job
+  # (release-java-central.yml) can request them on its own job. GitHub policy
+  # forbids a called workflow from holding permissions the caller hasn't
+  # authorized — omitting these manifests as a no-jobs `startup_failure`.
+  id-token: write
+  attestations: write
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -35,15 +41,12 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # publish:
-  #   needs: release-please
-  #   if: needs.release-please.outputs.release_created == 'true'
-  #   uses: promptLM/.github/.github/workflows/release-java-central.yml@main
-  #   with:
-  #     version: ${{ needs.release-please.outputs.tag_name }}
-  #     java-version: '21'
-  #     environment: maven-central-publish
-  #   secrets: inherit
-  #
-  # Temporarily disabled to isolate a startup_failure cause. Will be re-enabled
-  # once the cause is understood.
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: promptLM/.github/.github/workflows/release-java-central.yml@main
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}
+      java-version: '21'
+      environment: maven-central-publish
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Re-enable the \`publish:\` job in [release-please.yml](.github/workflows/release-please.yml) (disabled in [#79](https://github.com/promptLM/promptlm-junit-gitea-artifactory/pull/79) for diagnostic isolation).
- Add \`id-token: write\` and \`attestations: write\` at the workflow-level \`permissions\` block.

## Why startup_failure happened

The org reusable workflow [\`release-java-central.yml\`](https://github.com/promptLM/.github/blob/main/.github/workflows/release-java-central.yml)'s \`deploy\` job declares:

\`\`\`yaml
permissions:
  contents: read
  id-token: write
  attestations: write
\`\`\`

GitHub policy: a called workflow's job can only request permissions the **calling workflow has authorized**. Our caller declared only \`contents: write\` + \`pull-requests: write\`, so when GitHub built the job graph it found the called \`deploy\` job asking for un-granted permissions and rejected the run — manifesting as \`startup_failure\` with zero jobs and no log (runs [26845334583](https://github.com/promptLM/promptlm-junit-gitea-artifactory/actions/runs/26845334583), [26846212723](https://github.com/promptLM/promptlm-junit-gitea-artifactory/actions/runs/26846212723)).

Granting the two missing permissions at the caller level lets the called job hold them. Both are additive; neither weakens the caller's own posture.

## End-to-end path after this merges

1. This PR's merge push triggers \`release-please\`. The \`release-please\` job runs and doesn't produce \`release_created=true\` (no release PR pending), so \`publish:\` is skipped via its \`if:\` gate. Successful no-op.
2. Then we merge [#82](https://github.com/promptLM/promptlm-junit-gitea-artifactory/pull/82) (the actual release PR for 1.3.0). On that merge push:
   - \`release-please\` job creates tag \`v1.3.0\` + GitHub Release (\`release_created=true\`).
   - \`publish\` job hands off to the org reusable.
   - Reusable runs: validate-inputs → verify → smoke-sign → deploy → promote.
   - \`promote\` is gated on the \`maven-central-publish\` environment (required reviewer: \`fabapp2\`). After approval, 1.3.0 is on Maven Central.

## Test plan

- [ ] On merge, \`release-please\` workflow run starts (no startup_failure) and completes as a no-op success.
- [ ] After [#82](https://github.com/promptLM/promptlm-junit-gitea-artifactory/pull/82) merges, \`release-please\` creates v1.3.0 tag and the \`publish\` job runs the reusable workflow's five-job pipeline.
- [ ] Promote is held at the \`maven-central-publish\` environment for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)