### PR TITLE
feat(ci): add manual republish dispatcher for the org reusable workflow

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,43 @@
+name: republish
+
+# Manual dispatcher for publishing (or re-publishing) a specific tag to
+# Maven Central. Useful when:
+#   - release-please created the release but the publish leg failed
+#     (e.g. a transient verify/deploy error, or — as for v1.3.0 — a stale
+#     reusable-workflow resolution that gh run rerun won't refresh).
+#   - we need to ship a hotfix tag created out-of-band.
+#
+# This workflow is intentionally a thin caller around the org reusable so
+# the rerun semantics and approval gates are identical to the normal flow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to publish (e.g. v1.3.0). The leading v is stripped by the reusable.'
+        required: true
+        type: string
+      dry-run:
+        description: 'Build and sign but do not deploy or promote'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: republish-${{ github.ref }}-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    uses: promptLM/.github/.github/workflows/release-java-central.yml@main
+    with:
+      version: ${{ inputs.version }}
+      dry-run: ${{ inputs.dry-run }}
+      java-version: '21'
+      environment: maven-central-publish
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds [.github/workflows/republish.yml](.github/workflows/republish.yml) — a thin \`workflow_dispatch\` wrapper around \`promptLM/.github/.github/workflows/release-java-central.yml@main\` that takes a \`version\` input and triggers the full publish pipeline (validate-inputs → verify → smoke-sign → deploy → promote) against the supplied tag.

## Why

When [run 26847786856](https://github.com/promptLM/promptlm-junit-gitea-artifactory/actions/runs/26847786856) failed the \`verify\` job because the reusable workflow's actions were unpinned ([promptLM/.github#16](https://github.com/promptLM/.github/pull/16) fixed it), \`gh run rerun --failed\` re-used the originally-resolved reusable SHA (\`641b74e8...\`, the org main commit before the pin fix) instead of re-resolving \`@main\`. The rerun therefore hit the same un-pinned actions and failed again.

A fresh \`workflow_dispatch\` triggers a fresh resolution, picking up the current org main HEAD. Dispatching this workflow with \`version=v1.3.0\` will publish 1.3.0 to Maven Central.

## Followups

- Org repo: the squash-merge of [promptLM/.github#16](https://github.com/promptLM/.github/pull/16) used my first commit's SHA (\`de0fac2e...\`, which is actually \`actions/checkout@v6.0.2\`, not v6.0.3 as the comment claims). Both satisfy the action-pin policy so it doesn't block publishing — but the mislabel is worth correcting in a small follow-up org PR.

## Test plan

- [ ] Merge this PR.
- [ ] From the Actions tab, run **republish** with \`version=v1.3.0\` and \`dry-run=false\`.
- [ ] Pipeline progresses through verify → smoke-sign → deploy → promote.
- [ ] \`promote\` pauses at the \`maven-central-publish\` environment for the required reviewer (\`fabapp2\`).
- [ ] After approval, 1.3.0 lands on Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)