### PR TITLE
fix: honor central-publishing promote gate (autoPublish=false, waitUntil=validated)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,8 +254,8 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
-                            <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
+                            <autoPublish>false</autoPublish>
+                            <waitUntil>validated</waitUntil>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## Summary

Flip the central-publishing-maven-plugin config to honor the org reusable
workflow's `deploy → human-gate → promote` contract.

| Before | After |
|---|---|
| `<autoPublish>true</autoPublish>` | `<autoPublish>false</autoPublish>` |
| `<waitUntil>published</waitUntil>` | `<waitUntil>validated</waitUntil>` |

## Why

The org reusable `release-java-central.yml` is designed around two-phase
publish: the `deploy` job uploads + validates at the Portal; the separate
`promote` job (gated by the `maven-central-publish` GitHub environment
with required reviewers) calls the publisher API to move the deployment
to PUBLISHED. The promote gate is the human-review checkpoint between
"the bundle was accepted by Central" and "the bundle is public on Maven
Central forever."

This repo's pom config bypassed that gate. Symptom during v1.3.0:
- `deploy` job released artifacts to public Central immediately (because
  `autoPublish=true` told the plugin to flip PUBLISHED in one go).
- `promote` job sat `waiting` on the env, then got cancelled — it had no
  work to do; the deployment was already PUBLISHED.

## What changes operationally

With this config:

1. `deploy` runs `mvn -Prelease deploy`. The plugin uploads the bundle,
   waits for the Portal to return state `VALIDATED`, captures the
   `deploymentId`, and exits success. Nothing public yet.
2. `promote` blocks at the `maven-central-publish` environment for the
   required-reviewers approval (configured per-repo, currently you).
3. On approval, `promote` POSTs to
   `https://central.sonatype.com/api/v1/publisher/deployment/<id>`. The
   deployment moves to `PUBLISHING` then `PUBLISHED`. Artifacts land on
   `repo.maven.apache.org` within a few minutes.

Recovery value: had this been in place during v1.3.0, the
"Could not find a public key by the key fingerprint" rejection would
have surfaced at `VALIDATED` with the bundle still droppable from the
Portal (no public-visible failed deployment). Same fixes, but
contained inside the Portal staging area.

## Test plan
- [x] After merge: release-please PR #85 auto-updates to include this
      commit in 1.4.0's "Fixed" section.
- [ ] Merging #85 will cut 1.4.0. The publish chain will exercise the
      gate end-to-end: `deploy` should stop at VALIDATED;
      `promote` should require approval before artifacts go public.
- [ ] If something rejects at VALIDATED, drop the deployment from the
      Portal UI; no public artifacts to retract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)